### PR TITLE
Refactoring to support basic polling and OCaml bindings through Ctypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 native/k.h
+native/obj
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 native/k.h
+native/obj

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 native/k.h
 native/obj
+.vscode

--- a/native/Makefile
+++ b/native/Makefile
@@ -20,7 +20,7 @@ LIBS=-lm
 DEPS=k.h wire.h mock_k.h shmipc.h
 OBJECTS=$(ODIR)/shmipc.o $(ODIR)/mock_k.o
 
-all: $(ODIR)/mock_k.o $(ODIR)/shmipc.o $(ODIR)/shmmain
+all: $(ODIR)/mock_k.o $(ODIR)/shmipc.o $(ODIR)/shmmain $(ODIR)/libocamlshmipc.so $(ODIR)/ocamlshmipcmain
 
 k.h:
 	wget https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h
@@ -32,6 +32,12 @@ $(ODIR)/shmipc.o: shmipc.c $(ODIR)/mock_k.o $(DEPS)
 	$(CC) -c -o $@ $< $(ODIR)/mock_k.o $(CFLAGS) $(CDFLAGS)
 
 $(ODIR)/shmmain: shmmain.c $(DEPS) $(OBJECTS)
+	$(CC) -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
+
+$(ODIR)/libocamlshmipc.so: ocamlshmipc.c $(OBJECTS)
+	$(CC) -shared -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
+
+$(ODIR)/ocamlshmipcmain: ocamlshmipcmain.c $(DEPS) $(OBJECTS)
 	$(CC) -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
 
 coverage: obj/shmcov
@@ -54,7 +60,7 @@ fuzz: $(ODIR)/shmmain.fuzz
 	afl-fuzz -i test/fuzz_input -o test/fuzz_output $(ODIR)/shmmain.fuzz -F - :../java/out
 
 $(ODIR)/shmmain.fuzz: shmmain.c shmipc.c mock_k.h $(DEPS)
-	/usr/local/Cellar/afl-fuzz/2.52b/bin/afl-clang -o $@ $< $(CFLAGS) -g -O0
+	/home/jonathan/dev/git/AFL -o $@ $< $(CFLAGS) -g -O0
 
 .PHONY: clean grind coverage syms fuzz
 

--- a/native/Makefile
+++ b/native/Makefile
@@ -6,8 +6,8 @@ detected_OS := $(shell uname -s)
 
 IDIR=.
 CC=gcc
-CFLAGS=-DKXVER=3 -fPIC -I$(IDIR) -Wall
-CDFLAGS=-shared
+CFLAGS=-DKXVER=3 -fPIC -I$(IDIR) -Wall -g3 -gdwarf -g2
+#CDFLAGS=-shared
 ifeq ($(detected_OS),Darwin)  # Mac OS X
     CDFLAGS += -undefined dynamic_lookup
 endif
@@ -17,18 +17,29 @@ endif
 
 ODIR=obj
 LIBS=-lm
-DEPS = k.h wire.h
+DEPS=k.h wire.h mock_k.h shmipc.h
+OBJECTS=$(ODIR)/shmipc.o $(ODIR)/mock_k.o
 
-all: obj/hpet.so obj/shmipc.so obj/shmmain
+all: $(ODIR)/mock_k.o $(ODIR)/shmipc.o $(ODIR)/shmmain $(ODIR)/libocamlshmipc.so $(ODIR)/ocamlshmipcmain
 
 k.h:
 	wget https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h
 
-$(ODIR)/%.so: %.c $(DEPS)
-	$(CC) -o $@ $< $(CFLAGS) $(CDFLAGS)
 
-$(ODIR)/shmmain: shmmain.c shmipc.c mock_k.h $(DEPS)
-	$(CC) -o $@ $< $(CFLAGS) -g -O0
+$(ODIR)/mock_k.o: mock_k.c $(DEPS)
+	$(CC) -c -o $@ $< $(CFLAGS) $(CDFLAGS)
+
+$(ODIR)/shmipc.o: shmipc.c $(ODIR)/mock_k.o $(DEPS)
+	$(CC) -c -o $@ $< $(ODIR)/mock_k.o $(CFLAGS) $(CDFLAGS)
+
+$(ODIR)/shmmain: shmmain.c $(DEPS) $(OBJECTS)
+	$(CC) -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
+
+$(ODIR)/libocamlshmipc.so: ocamlshmipc.c $(OBJECTS)
+	$(CC) -shared -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
+
+$(ODIR)/ocamlshmipcmain: ocamlshmipcmain.c $(DEPS) $(OBJECTS)
+	$(CC) -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
 
 coverage: obj/shmcov
 	obj/shmcov -v -a WORLD :demo/stress
@@ -51,6 +62,7 @@ fuzz: $(ODIR)/shmmain.fuzz
 
 $(ODIR)/shmmain.fuzz: shmmain.c shmipc.c mock_k.h $(DEPS)
 	/usr/local/Cellar/afl-fuzz/2.52b/bin/afl-clang -o $@ $< $(CFLAGS) -g -O0
+
 
 .PHONY: clean grind coverage syms fuzz
 

--- a/native/Makefile
+++ b/native/Makefile
@@ -60,7 +60,8 @@ fuzz: $(ODIR)/shmmain.fuzz
 	afl-fuzz -i test/fuzz_input -o test/fuzz_output $(ODIR)/shmmain.fuzz -F - :../java/out
 
 $(ODIR)/shmmain.fuzz: shmmain.c shmipc.c mock_k.h $(DEPS)
-	/home/jonathan/dev/git/AFL -o $@ $< $(CFLAGS) -g -O0
+	/usr/local/Cellar/afl-fuzz/2.52b/bin/afl-clang -o $@ $< $(CFLAGS) -g -O0
+
 
 .PHONY: clean grind coverage syms fuzz
 

--- a/native/Makefile
+++ b/native/Makefile
@@ -25,6 +25,7 @@ all: $(ODIR)/mock_k.o $(ODIR)/shmipc.o $(ODIR)/shmmain $(ODIR)/libocamlshmipc.so
 k.h:
 	wget https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h
 
+
 $(ODIR)/mock_k.o: mock_k.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS) $(CDFLAGS)
 

--- a/native/Makefile
+++ b/native/Makefile
@@ -6,8 +6,8 @@ detected_OS := $(shell uname -s)
 
 IDIR=.
 CC=gcc
-CFLAGS=-DKXVER=3 -fPIC -I$(IDIR) -Wall
-CDFLAGS=-shared
+CFLAGS=-DKXVER=3 -fPIC -I$(IDIR) -Wall -g3 -gdwarf -g2
+#CDFLAGS=-shared
 ifeq ($(detected_OS),Darwin)  # Mac OS X
     CDFLAGS += -undefined dynamic_lookup
 endif
@@ -17,18 +17,22 @@ endif
 
 ODIR=obj
 LIBS=-lm
-DEPS = k.h wire.h
+DEPS=k.h wire.h mock_k.h shmipc.h
+OBJECTS=$(ODIR)/shmipc.o $(ODIR)/mock_k.o
 
-all: obj/hpet.so obj/shmipc.so obj/shmmain
+all: $(ODIR)/mock.o $(ODIR)/shmipc.o $(ODIR)/shmmain
 
 k.h:
 	wget https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h
 
-$(ODIR)/%.so: %.c $(DEPS)
-	$(CC) -o $@ $< $(CFLAGS) $(CDFLAGS)
+$(ODIR)/mock_k.o: mock_k.c $(DEPS)
+	$(CC) -c -o $@ $< $(CFLAGS) $(CDFLAGS)
 
-$(ODIR)/shmmain: shmmain.c shmipc.c mock_k.h $(DEPS)
-	$(CC) -o $@ $< $(CFLAGS) -g -O0
+$(ODIR)/shmipc.o: shmipc.c $(ODIR)/mock_k.o $(DEPS)
+	$(CC) -c -o $@ $< mock_k.o $(CFLAGS) $(CDFLAGS)
+
+$(ODIR)/shmmain: shmmain.c $(DEPS) $(OBJECTS)
+	$(CC) -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0
 
 coverage: obj/shmcov
 	obj/shmcov -v -a WORLD :demo/stress

--- a/native/Makefile
+++ b/native/Makefile
@@ -20,7 +20,7 @@ LIBS=-lm
 DEPS=k.h wire.h mock_k.h shmipc.h
 OBJECTS=$(ODIR)/shmipc.o $(ODIR)/mock_k.o
 
-all: $(ODIR)/mock.o $(ODIR)/shmipc.o $(ODIR)/shmmain
+all: $(ODIR)/mock_k.o $(ODIR)/shmipc.o $(ODIR)/shmmain
 
 k.h:
 	wget https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h
@@ -29,7 +29,7 @@ $(ODIR)/mock_k.o: mock_k.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS) $(CDFLAGS)
 
 $(ODIR)/shmipc.o: shmipc.c $(ODIR)/mock_k.o $(DEPS)
-	$(CC) -c -o $@ $< mock_k.o $(CFLAGS) $(CDFLAGS)
+	$(CC) -c -o $@ $< $(ODIR)/mock_k.o $(CFLAGS) $(CDFLAGS)
 
 $(ODIR)/shmmain: shmmain.c $(DEPS) $(OBJECTS)
 	$(CC) -o $@ $< $(OBJECTS) $(CFLAGS) -g -O0

--- a/native/mock_k.c
+++ b/native/mock_k.c
@@ -1,0 +1,148 @@
+// Copyright 2018 Tea Engineering Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// stub out kx layer (the extern function in k.h) so we can run in main, profile,
+// valgrind native code etc.
+//
+// It's impossible to find the source of memory leaks with the Kx slab allocator
+// as valgrind can't hook the individual allocations to record the stack.
+//
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "k.h"
+
+#define KERR -128
+
+// globals
+int kxx_errno = 0;
+char* kxx_msg = NULL;
+
+K krr(const S msg) {
+    printf("'%s\n", msg);
+    kxx_errno = -1;
+    kxx_msg = msg;
+    return (K)NULL;
+}
+K orr(const S msg) {
+    printf("%s\n", msg);
+    kxx_errno = -1;
+    kxx_msg = msg;
+    return (K)NULL;
+}
+K ee(K ignored) {
+    if (kxx_errno != 0) {
+        K r = ktn(KERR, 1);
+        r->s = kxx_msg;
+        kxx_errno = 0;
+        return r;
+    }
+    return ignored;
+}
+K ki(int i) {
+    K r = ktn(-KI, 0);
+    r->i = i;
+    return r;
+}
+K kj(long long i) {
+    K r = ktn(-KJ, 0);
+    r->j = i;
+    return r;
+}
+K kss(const char* ss) {
+    K r = ktn(-KS, 0);
+    r->s = (char*)ss;
+    return r;
+}
+K dl(void* fnptr, J n) {
+    K r = ktn(100,0);
+    r->s = fnptr;
+    //r->a = n;
+    return r;
+}
+
+typedef K (*kfunc_1arg)(K);
+typedef K (*kfunc_2arg)(K,K);
+typedef K (*kfunc_3arg)(K,K,K);
+
+K dot(K x, K y) { // call function pointer in x with args in mixed list y
+    if (x->t != 100) return krr("x must be fptr");
+    if (y->t != 0) return krr("y must be list");
+    //if (x->a == 2) { // not sure why this check was there
+    kfunc_2arg fptr = (kfunc_2arg)x->s;
+    return fptr(kK(y)[0], kK(y)[1]);
+}
+
+K knk(int n, ...) { // create a mixed list from K's in varg
+    va_list ap;
+    K r = ktn(0, n);
+    va_start(ap, n); //Requires the last fixed parameter (to get the address)
+    for(int j=0; j<n; j++) {
+        kK(r)[j] = va_arg(ap, K); //Requires the type to cast to. Increments ap to the next argument.
+    }
+    va_end(ap);
+    return r;
+}
+//                mx KB UU ?? KG KH KI KJ KE KF KC KS KP KM KD KZ KN KU KV KT
+//                0  1  2  -  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19
+int sizefor[] = { 8, 1, 16,0, 1, 2, 4, 8, 4, 8, 1, 8 ,8, 4, 4, 8, 8, 4, 4, 4 };
+K ktn(int type, long long n) { // K type number
+    int sz = (type > 19) ? 8 : sizefor[abs(type)];
+    K r = malloc(sizeof(struct k0) + n*sz);
+    r->r = 0;
+    r->t = type;
+    if (n > 0) r->n = n; // keep: trap accessing n for atom in valgrind
+    return r;
+}
+
+// dummy serialiser returns a single byte array [SOH]
+K b9(I mode, K obj) {
+    K r = ktn(KB,1);
+    r->G0[0] = 1;
+    return r;
+}
+
+K d9(K obj) {
+    return ki(1);
+}
+
+int okx(K obj) { return 1; }
+// repl equivelent wrapper (protected eval, with and without gc)
+K pe(K x) {
+    if (kxx_errno != 0) exit(-1);
+    return x;
+}
+void per(K x) {
+    pe(x);
+    if (x != NULL) r0(x);
+}
+
+void r0(K x) { // Decrement the object‘s reference count
+    if (x == 0) { printf("Bug r0 of null pointer %p\n", x); return; }
+    if (x->r < 0) printf("Bug double-free of %p\n", x);
+    if (x->r == 0) {
+        if (x->t == 0) for (int i = 0; i < x->n; i++) r0(kK(x)[i]);
+        // flip?
+        // dict?
+        free(x);
+    } else {
+        x->r--;
+    }
+}
+K r1(K x) { // Increment the object‘s reference count
+    x->r++;
+    return x;
+}
+

--- a/native/mock_k.h
+++ b/native/mock_k.h
@@ -18,126 +18,32 @@
 // It's impossible to find the source of memory leaks with the Kx slab allocator
 // as valgrind can't hook the individual allocations to record the stack.
 //
+#ifndef MOCK_K
+#define MOCK_K
 
-// globals
-int kxx_errno = 0;
-char* kxx_msg = NULL;
+#define KERR -128
 
-K krr(const S msg) {
-    printf("'%s\n", msg);
-    kxx_errno = -1;
-    kxx_msg = msg;
-    return (K)NULL;
-}
-K orr(const S msg) {
-    printf("%s\n", msg);
-    kxx_errno = -1;
-    kxx_msg = msg;
-    return (K)NULL;
-}
-K ee(K ignored) {
-    if (kxx_errno != 0) {
-        K r = ktn(KERR, 1);
-        r->s = kxx_msg;
-        kxx_errno = 0;
-        return r;
-    }
-    return ignored;
-}
-K ki(int i) {
-    K r = ktn(-KI, 0);
-    r->i = i;
-    return r;
-}
-K kj(long long i) {
-    K r = ktn(-KJ, 0);
-    r->j = i;
-    return r;
-}
-K kss(const char* ss) {
-    K r = ktn(-KS, 0);
-    r->s = (char*)ss;
-    return r;
-}
-K dl(void* fnptr, int n) {
-    K r = ktn(100,0);
-    r->s = fnptr;
-    r->a = n;
-    return r;
-}
+K krr(const S msg);
+K orr(const S msg);
+K ee(K ignored);
+K ki(int i);
+K kj(long long i);
+K kss(const char* ss);
+K dl(void* fnptr, J n);
 
 typedef K (*kfunc_1arg)(K);
 typedef K (*kfunc_2arg)(K,K);
 typedef K (*kfunc_3arg)(K,K,K);
 
-K dot(K x, K y) { // call function pointer in x with args in mixed list y
-    if (x->t != 100) return krr("x must be fptr");
-    if (y->t != 0) return krr("y must be list");
-    if (x->a == 2) {
-        kfunc_2arg fptr = (kfunc_2arg)x->s;
-        return fptr(kK(y)[0], kK(y)[1]);
-    }
-    return ki(1);
-}
+K dot(K x, K y);
+K knk(int n, ...);
+K ktn(int type, long long n);// dummy serialiser returns a single byte array [SOH]
+K b9(I mode, K obj);
+K d9(K obj);
+int okx(K obj);
+K pe(K x);
+void per(K x);
+void r0(K x);
+K r1(K x);
 
-K knk(int n, ...) { // create a mixed list from K's in varg
-    va_list ap;
-    K r = ktn(0, n);
-    va_start(ap, n); //Requires the last fixed parameter (to get the address)
-    for(int j=0; j<n; j++) {
-        kK(r)[j] = va_arg(ap, K); //Requires the type to cast to. Increments ap to the next argument.
-    }
-    va_end(ap);
-    return r;
-}
-//                mx KB UU ?? KG KH KI KJ KE KF KC KS KP KM KD KZ KN KU KV KT
-//                0  1  2  -  4  5  6  7  8  9  10 11 12 13 14 15 16 17 18 19
-int sizefor[] = { 8, 1, 16,0, 1, 2, 4, 8, 4, 8, 1, 8 ,8, 4, 4, 8, 8, 4, 4, 4 };
-K ktn(int type, long long n) { // K type number
-    int sz = (type > 19) ? 8 : sizefor[abs(type)];
-    K r = malloc(sizeof(struct k0) + n*sz);
-    r->r = 0;
-    r->t = type;
-    if (n > 0) r->n = n; // keep: trap accessing n for atom in valgrind
-    return r;
-}
-
-// dummy serialiser returns a single byte array [SOH]
-K b9(I mode, K obj) {
-    K r = ktn(KB,1);
-    r->G0[0] = 1;
-    return r;
-}
-
-K d9(K obj) {
-    return ki(1);
-}
-
-int okx(K obj) { return 1; }
-// repl equivelent wrapper (protected eval, with and without gc)
-K pe(K x) {
-    if (kxx_errno != 0) exit(-1);
-    return x;
-}
-void per(K x) {
-    pe(x);
-    if (x != NULL) r0(x);
-}
-
-void r0(K x) { // Decrement the object‘s reference count
-    if (x == 0) { printf("Bug r0 of null pointer %p\n", x); return; }
-    if (x->r < 0) printf("Bug double-free of %p\n", x);
-    if (x->r == 0) {
-        if (x->t == 0) for (int i = 0; i < x->n; i++) r0(kK(x)[i]);
-        // flip?
-        // dict?
-        free(x);
-    } else {
-        x->r--;
-    }
-}
-K r1(K x) { // Increment the object‘s reference count
-    x->r++;
-    return x;
-}
-
+#endif

--- a/native/obj/.gitignore
+++ b/native/obj/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/native/ocamlshmipc.c
+++ b/native/ocamlshmipc.c
@@ -1,0 +1,61 @@
+#include "shmipc.h"
+#include "mock_k.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Store the passed in funptr so we can wrap it
+void(*extern_cb_funptr)(uint64_t, const char*, uint64_t);
+
+K kdb_to_ocaml_cb(K x, K y) {
+    extern_cb_funptr(x->j, y, y->n);
+	return ki(5);
+}
+
+int parse_data_raw(unsigned char* base, int lim, uint64_t index, void* userdata) {
+    printf(" pdr text: %llu '%.*s'\n", index, lim, base);
+    char* c = malloc((lim)*sizeof(char));
+    memcpy(c, base, lim);
+    extern_cb_funptr(index, c, lim);
+    free(c);
+    return 0;
+}
+const parsedata_f* parser = &parse_data_raw;
+
+int append_data_raw(unsigned char* base, int lim, int* sz, K msg) {
+    return 0;
+}
+const appenddata_f* appender = &append_data_raw;
+
+K append_check_raw(queue_t* queue, K msg) {
+    return msg;
+}
+const encodecheck_f* encoder = &append_check_raw;
+
+
+
+void OCAMLshmipc_open_and_poll(const char* dirpath, void(*cb_funptr)(uint64_t, uint64_t)) {
+    K dir = kss(dirpath);
+    K parser = kss("text");
+    uint64_t index = 0;
+    per(shmipc_init(dir, parser, appender, encoder));
+
+    extern_cb_funptr = cb_funptr;
+    K cb = dl(&kdb_to_ocaml_cb, 2);
+    K kindex = kj(index);
+    per(shmipc_tailer(dir, cb, kindex));
+    per(shmipc_peek(dir));
+    per(shmipc_debug((K)NULL));
+
+    while (1) {
+		usleep(500*1000);
+		per(shmipc_peek(dir));
+	}
+
+	per(shmipc_close(dir));
+
+	r0(dir);
+	r0(parser);
+	r0(cb);
+	r0(index);
+}

--- a/native/ocamlshmipc.c
+++ b/native/ocamlshmipc.c
@@ -1,0 +1,63 @@
+#include "shmipc.h"
+#include "mock_k.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+Easy to use ocaml bindings for the 'open and tailing' use case.
+
+OCAMLshmipc_open_and_poll takes a directory and callback function that will get called on each CQ message.
+*/
+
+// Store the passed in funptr so we can wrap it
+void(*extern_cb_funptr)(uint64_t, const char*, uint64_t);
+
+K kdb_to_ocaml_cb(K x, K y) {
+    extern_cb_funptr(x->j, y, y->n);
+	return ki(5);
+}
+
+int parse_data_raw(unsigned char* base, int lim, uint64_t index, void* userdata) {
+    char* c = malloc((lim+1)*sizeof(char));
+    c[lim] = '\0';
+    memcpy(c, base, lim);
+    extern_cb_funptr(index, c, lim);
+    free(c);
+    return 0;
+}
+const parsedata_f* parser = &parse_data_raw;
+
+int append_data_raw(unsigned char* base, int lim, int* sz, K msg) {
+    return 0;
+}
+const appenddata_f* appender = &append_data_raw;
+
+K append_check_raw(queue_t* queue, K msg) {
+    return msg;
+}
+const encodecheck_f* encoder = &append_check_raw;
+
+
+
+void OCAMLshmipc_open_and_poll(const char* dirpath, void(*cb_funptr)(uint64_t, const char*, uint64_t)) {
+    K dir = kss(dirpath);
+    uint64_t index = 0;
+    per(shmipc_init(dir, parser, appender, encoder));
+
+    extern_cb_funptr = cb_funptr;
+    K cb = dl(&kdb_to_ocaml_cb, 2);
+    K kindex = kj(index);
+    per(shmipc_tailer(dir, cb, kindex));
+    per(shmipc_peek(dir));
+    while (1) {
+		usleep(500*1000);
+		per(shmipc_peek(dir));
+	}
+
+	per(shmipc_close(dir));
+
+	r0(dir);
+	r0(cb);
+	r0(index);
+}

--- a/native/ocamlshmipcmain.c
+++ b/native/ocamlshmipcmain.c
@@ -1,0 +1,24 @@
+#include "shmipc.h"
+#include "mock_k.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ocamlshmipc.c"
+
+/*
+A simple debugging tool for ocamlshmipc
+*/
+
+
+void cb_test(uint64_t index, const char* data, uint64_t len)
+{
+    printf("\t\tcb_test index:%llu len:%llu data:'%.*s'\n", index, len, len, data);
+}
+
+int main(const int argc, char** argv)
+{
+    char* dir = ":/home/jonathan/dev/git/c-chronicle-q/queue";
+    OCAMLshmipc_open_and_poll(dir, &cb_test);
+    return 0;
+}

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -261,7 +261,7 @@ int dispatch_callback(tailer_t* tailer, uint64_t index, K obj) {
 
 int parse_data_text(unsigned char* base, int lim, uint64_t index, void* userdata) {
     tailer_t* tailer = (tailer_t*)userdata;
-    if (debug) printf(" pdt text: %" PRIu64 " '%.*s'\n", index, lim, base);
+    if (debug) printf(" text: %" PRIu64 " '%.*s'\n", index, lim, base);
     // prep args and fire callback
     if (tailer->callback && index > tailer->dispatch_after) {
         K msg = ktn(KC, lim); // don't free this, handed over to q interp

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -261,14 +261,13 @@ int dispatch_callback(tailer_t* tailer, uint64_t index, K obj) {
 
 int parse_data_text(unsigned char* base, int lim, uint64_t index, void* userdata) {
     tailer_t* tailer = (tailer_t*)userdata;
-    //printf(" pdt text: %" PRIu64 " '%.*s'\n", index, lim, base);
+    if (debug) printf(" pdt text: %" PRIu64 " '%.*s'\n", index, lim, base);
     // prep args and fire callback
     if (tailer->callback && index > tailer->dispatch_after) {
         K msg = ktn(KC, lim); // don't free this, handed over to q interp
         memcpy((char*)msg->G0, base, lim);
         return dispatch_callback(tailer, index, msg);
-    } else {
-    }
+    } 
     return 0;
 }
 

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -29,7 +29,9 @@
 #include <glob.h>
 #include <time.h>
 
+#include "shmipc.h"
 #include "k.h"
+#include "mock_k.h"
 #include "wire.h"
 
 /**
@@ -259,13 +261,13 @@ int dispatch_callback(tailer_t* tailer, uint64_t index, K obj) {
 
 int parse_data_text(unsigned char* base, int lim, uint64_t index, void* userdata) {
     tailer_t* tailer = (tailer_t*)userdata;
-    if (debug) printf(" text: %" PRIu64 " '%.*s'\n", index, lim, base);
-
+    //printf(" pdt text: %" PRIu64 " '%.*s'\n", index, lim, base);
     // prep args and fire callback
     if (tailer->callback && index > tailer->dispatch_after) {
         K msg = ktn(KC, lim); // don't free this, handed over to q interp
         memcpy((char*)msg->G0, base, lim);
         return dispatch_callback(tailer, index, msg);
+    } else {
     }
     return 0;
 }
@@ -317,17 +319,15 @@ K append_check_kx(queue_t* queue, K msg) {
     return r;
 }
 
-K shmipc_init(K dir, K parser) {
+
+K shmipc_init(K dir, parsedata_f* parser, appenddata_f* appender, encodecheck_f* encoder) {
     if (dir->t != -KS) return krr("dir is not symbol");
     if (dir->s[0] != ':') return krr("dir is not symbol handle (starts with :)");
-    if (parser->t != -KS) return krr("parser is not symbol");
 
     debug = getenv("SHMIPC_DEBUG");
     wire_trace = getenv("SHMIPC_WIRETRACE");
 
     pid_header = (getpid() & HD_MASK_LENGTH);
-
-    printf("shmipc: opening dir %s format %s\n", dir->s, parser->s);
 
     // check if queue already open
     queue_t* queue = queue_head;
@@ -417,18 +417,9 @@ K shmipc_init(K dir, K parser) {
     //  cycleShift = Math.max(32, Maths.intLog2(indexCount) * 2 + Maths.intLog2(indexSpacing));
 
     // verify user-specified parser for data segments
-    if (strncmp(parser->s, "text", parser->n) == 0) {
-        queue->parser = &parse_data_text;
-        queue->encoder = &append_data_text;
-        queue->encodecheck = &append_check_text;
-    } else if (strncmp(parser->s, "kx", parser->n) == 0) {
-        queue->parser = &parse_data_kx;
-        queue->encoder = &append_data_kx;
-        queue->encodecheck = &append_check_kx;
-    } else {
-        return krr("bad format: supports `kx and `text");
-    }
-    if (debug) printf("shmipc: format set to %.*s\n", (int)parser->n, parser->s);
+    queue->parser = parser;
+    queue->encoder = appender;
+    queue->encodecheck = encoder;
 
     // Good to use
     queue->next = queue_head;

--- a/native/shmipc.h
+++ b/native/shmipc.h
@@ -1,0 +1,34 @@
+#ifndef SHIMPC
+#define SHIMPC
+
+#include <stdint.h>
+
+#include "k.h"
+
+//typedef struct tailer tailer_t;
+typedef struct queue queue_t;
+
+typedef int (*parsedata_f)(unsigned char*,int,uint64_t,void* userdata);
+typedef int (*appenddata_f)(unsigned char*,int,int*,K);
+typedef K (*encodecheck_f)(struct queue*,K);
+
+int parse_data_text(unsigned char* base, int lim, uint64_t index, void* userdata);
+int append_data_text(unsigned char* base, int lim, int* sz, K msg);
+K append_check_text(queue_t* queue, K msg);
+
+int parse_data_kx(unsigned char* base, int lim, uint64_t index, void* userdata);
+int append_data_kx(unsigned char* base, int lim, int* sz, K msg);
+K append_check_kx(queue_t* queue, K msg);
+
+
+K shmipc_init(K dir, parsedata_f* parser, appenddata_f* appender, encodecheck_f* encoder);
+
+K shmipc_peek(K x);
+
+K shmipc_tailer(K dir, K cb, K kindex);
+
+K shmipc_debug(K x);
+
+K shmipc_close(K dir);
+
+#endif

--- a/native/shmmain.c
+++ b/native/shmmain.c
@@ -22,6 +22,7 @@
 
 #include "k.h"
 #include "shmipc.h"
+#include "mock_k.h"
 
 // This is a stand-alone tool for replaying a queue for use with valgrind etc that are tricky to
 // operate within KDB, e.g. with

--- a/native/shmmain.c
+++ b/native/shmmain.c
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <shmipc.c>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
-#include "mock_k.h"
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include "k.h"
+#include "shmipc.h"
 
 // This is a stand-alone tool for replaying a queue for use with valgrind etc that are tricky to
 // operate within KDB, e.g. with
@@ -142,9 +148,23 @@ int main(const int argc, char **argv) {
 	}
 
 	// what follows is translated q calls from shmipc.q
+	K parser_type = kss(kxflag ? "kx" : "text");
 	K dir = kss(argv[optind]);
-	K parser = kss(kxflag ? "kx" : "text");
-	per(shmipc_init(dir, parser));
+	parsedata_f parser;
+	appenddata_f appender;
+	encodecheck_f encoder;
+    if (strncmp(parser_type->s, "text", parser_type->n) == 0) {
+        parser = &parse_data_text;
+        appender = &append_data_text;
+        encoder = &append_check_text;
+    } else if (strncmp(parser_type->s, "kx", parser_type->n) == 0) {
+        parser = &parse_data_kx;
+        appender = &append_data_kx;
+        encoder = &append_check_kx;
+    } else {
+        return krr("bad format: supports `kx and `text");
+    }
+	per(shmipc_init(dir, parser, appender, encoder));
 
 	K cb = dl(&printxy, 2);
 	K kindex = kj(index);
@@ -244,7 +264,7 @@ int main(const int argc, char **argv) {
 	per(shmipc_close(dir));
 
 	r0(dir);
-	r0(parser);
+	r0(parser_type);
 	r0(cb);
 	r0(kindex);
 

--- a/native/shmmain.c
+++ b/native/shmmain.c
@@ -15,6 +15,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
Wanted to leverage this wonderful library to build an interface to help with bindings for OCaml. Right now this justs supports opening a CQ file and polling it and passing each message back to OCaml through a callback. In terms of the support for OCaml all that was really done was to expose the functionality through a plain c-style format rather having it wrapped in the Kdb C objects.

I don't use C that much and especially Makefiles... so a bit of trial and error here. Regarding the makefile definitely broke the *.so building and likely some other things. I wanted the makefile to produce a single libocamlshmipc.so which has all the linking done for a stand alone package to develop against for ocaml.

Sample polling OCaml usage once the libocamlshmipc.so is on the LD_LIBRARY_PATH.
```ocaml
open Ctypes
open Foreign

let cb_t = uint64_t @-> string @-> uint64_t @-> returning void

let open_and_poll' = foreign "OCAMLshmipc_open_and_poll" (string @-> funptr cb_t @-> returning void)

let open_and_poll st cb = 
    let cb' addr str len = cb 
        (Unsigned.UInt64.to_int addr)
        str
        (Unsigned.UInt64.to_int len)
    in
    open_and_poll' st cb'

let () = 
    let dir = Array.get (Sys.get_argv ()) 1 in
    let cb index str len = 
        print_endline (Printf.sprintf "IN OCAML: index:%d len:%d data:%s " index len str
    in
    open_and_poll dir cb
```