### PR TITLE
Support queue v5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,10 +17,11 @@ Chronicle Queue v5
   * format (text)
 * queue metatdata wire encoder changes:
   * `SCQSIndexing.indexSpacing` changes from `uint8` to `uint16`
-  *
+* a v5 queue with no data written can be a metadata.cq4t with no queue files (relax queuefile existance checks)
 * SingleChronicleQueueBuilder writeText() seems to be writing a one-byte prefix to the data
 
 
 Chronicle Queue v4
 ----
-* Everything
+* requires at least one queuefile to learn the roll scheme, although we do not know what the rollscheme is to find the queuefile, so bootstrap using filesystem glob
+

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,16 @@ Chronicle Queue v5
 * FAST_XXX RollSchemes see https://github.com/OpenHFT/Chronicle-Queue/blob/ea/src/main/java/net/openhft/chronicle/queue/RollCycles.java
 
 * Default RollScheme (e.g. for SingleChronicleQueueBuilder) changes from `DAILY` to `FAST_DAILY`
+* Since schemes make reduced bits available for cycle value, new concept of "epoch" which appears to be a constant offset to the cycle value, ie. we now longer assume epoch is midnight 1970.01.01
 * New per-queue `metadata.cq4t` file replaces `directory-listing.cq4t` file.
+  * STStore -> SCQMeta -> SCQSRoll fields need to be parsed since they are removed from queue files:
+  * length (uint32)
+  * epoch (uint8)
+  * format (text)
+* queue metatdata wire encoder changes:
+  * `SCQSIndexing.indexSpacing` changes from `uint8` to `uint16`
+  *
+* SingleChronicleQueueBuilder writeText() seems to be writing a one-byte prefix to the data
 
 
 Chronicle Queue v4

--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ of writes through to read visibility. Tailers need to use an 'mfence' between re
 and payload to ensure payload is not prematurely fetched and decoded before the working signal
 is clear. mfence used in this way stops both compiler re-ordering and cpu prefetch.
 
-The `directory-listing.cq4t` file is a simple counter of the min and max cycles, which is used
-to avoid probing the file system execessively with `stat` system calls during a reply and around the dateroll. It is memory-mapped to
-allow tailers to see cycle rolls in real time.
+The `directory-listing.cq4t` file (v4) or `metadata.cq4t` file (v5) is a simple counter of the min and max cycles, which is used
+to avoid probing the file system execessively with `stat` system calls during a reply and around the dateroll. It is memory-mapped into all appenders and tailers to see cycle rolls in real time.
 
 ## Bindings
 
@@ -64,7 +63,9 @@ Planned:
 - nodejs
 
 ## Issues
-The tool `shmmain` can replay, or follow, _DAILY_ queue files as writers proceed. So far as I can tell `shmmain` is compatable with the `InputMain` and `OutputMain` exmaples provided by Chronicle Software Ltd.
+The tool `shmmain` can replay, or follow, _DAILY_ or _DAILY_FAST_ queues files as writers proceed. So far as I can tell `shmmain` is compatable with the `InputMain` and `OutputMain` exmaples provided by Chronicle Software Ltd, with either v4 or v5 queues.
+
+It cannot yet use or append to index pages #1 or create a completely empty queue #15.
 
 If you can reproduce a segfault on an otherwise valid queuefile, examples would be happily recieved via. a Github Issue.
 

--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ Then
 
     $ mvn dependency:copy-dependencies
     $ mvn package
-    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.InputMain < sample.input
+    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.InputMain q1 < sample.input
     type something
     [81346680586240] one
     [81346680586241] two
@@ -21,11 +21,11 @@ Then
     Input stream finished
     $
 
-InputMain will create a directory called 'queue' in the current directory containing a queuefile (`*.cq4`) and a `metadata.cq4t` file. The file will contain three messages in the current cycle.
+InputMain will create a directory called 'q1' in the current directory containing a queuefile (`*.cq4`) and a `metadata.cq4t` file. The file will contain three messages in the current cycle.
 
 For the tailer:
 
-    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.OutputMain 2>/dev/null
+    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.OutputMain q1 2>/dev/null
     [81346680586240] one
     [81346680586241] two
     [81346680586242] three
@@ -36,7 +36,7 @@ For the tailer:
 Java write, libchronicle read:
 
     $ make -C ../native
-    $ ../native/obj/shmmain :queue/ -d 2>/dev/null
+    $ ../native/obj/shmmain :q1/ -d 2>/dev/null
     [81346680586240] one
     [81346680586241] two
     [81346680586242] three
@@ -44,4 +44,7 @@ Java write, libchronicle read:
 
 libchronicle write, Java read:
 
-    $ ../native/obj/shmmain :queue/ -d -a HELLO
+    TODO: support wire encoding for text round trip to work!
+    $ ../native/obj/shmmain :q1/ -d -a HELLO
+    $ ../native/obj/shmmain :q1/ -d
+    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.OutputMain q1

--- a/java/README.md
+++ b/java/README.md
@@ -25,11 +25,23 @@ InputMain will create a directory called 'queue' in the current directory contai
 
 For the tailer:
 
-    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.OutputMain
-    ....
+    $ java -cp target/java-1.0-SNAPSHOT.jar:target/dependency/chronicle-queue-5.20.102.jar mains.OutputMain 2>/dev/null
     [81346680586240] one
     [81346680586241] two
     [81346680586242] three
     $
 
-You can test basic interoperability
+### Interoperability
+
+Java write, libchronicle read:
+
+    $ make -C ../native
+    $ ../native/obj/shmmain :queue/ -d 2>/dev/null
+    [81346680586240] one
+    [81346680586241] two
+    [81346680586242] three
+    $
+
+libchronicle write, Java read:
+
+    $ ../native/obj/shmmain :queue/ -d -a HELLO

--- a/java/src/main/java/mains/InputMain.java
+++ b/java/src/main/java/mains/InputMain.java
@@ -11,7 +11,11 @@ import java.util.Scanner;
  */
 public class InputMain {
     public static void main(String[] args) {
-        String path = "queue";
+        if (args.length < 1) {
+            System.err.println("InputMain QUEUE");
+            System.exit(1);
+        }
+        String path = args[0];
         SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(path).build();
         ExcerptAppender appender = queue.acquireAppender();
         Scanner read = new Scanner(System.in);

--- a/java/src/main/java/mains/OutputMain.java
+++ b/java/src/main/java/mains/OutputMain.java
@@ -10,7 +10,11 @@ import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
  */
 public class OutputMain {
     public static void main(String[] args) {
-        String path = "queue";
+        if (args.length < 1) {
+            System.err.println("OutputMain QUEUE");
+            System.exit(1);
+        }
+        String path = args[0];
         SingleChronicleQueue queue = SingleChronicleQueueBuilder.binary(path).build();
         ExcerptTailer tailer = queue.createTailer();
 

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -1081,7 +1081,7 @@ K shmipc_tailer(K dir, K cb, K kindex) {
     if (tailer == NULL) return krr("tm fail");
     bzero(tailer, sizeof(tailer_t));
 
-    tailer->dispatch_after = index;
+    tailer->dispatch_after = index - 1;
     tailer->qf_index = index & ~queue->seqnum_mask; // start replay from first entry in file
     tailer->callback = cb;
     tailer->state = 5;

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -825,9 +825,9 @@ K shmipc_debug(K x) {
 void shmipc_debug_tailer(queue_t* queue, tailer_t* tailer) {
     const char* state_text = tailer_state_messages[tailer->state];
     printf("    callback         %p\n",   tailer->callback);
-    int cycle = tailer->dispatch_after >> queue->cycle_shift;
-    int seqnum = tailer->dispatch_after & queue->seqnum_mask;
-    printf("    dispatch_after   %" PRIu64 " (cycle %d, seqnum %d)\n", tailer->dispatch_after, cycle, seqnum);
+    uint cycle = tailer->dispatch_after >> queue->cycle_shift;
+    uint seqnum = tailer->dispatch_after & queue->seqnum_mask;
+    printf("    dispatch_after   %" PRIu64 " (cycle %u, seqnum %u)\n", tailer->dispatch_after, cycle, seqnum);
     printf("    state            %d - %s\n", tailer->state, state_text);
     printf("    qf_fn            %s\n",   tailer->qf_fn);
     printf("    qf_fd            %d\n",   tailer->qf_fd);
@@ -835,7 +835,7 @@ void shmipc_debug_tailer(queue_t* queue, tailer_t* tailer) {
     printf("    qf_tip           %" PRIu64 "\n", tailer->qf_tip);
     cycle = tailer->qf_index >> queue->cycle_shift;
     seqnum = tailer->qf_index & queue->seqnum_mask;
-    printf("    qf_index         %" PRIu64 " (cycle %d, seqnum %d)\n", tailer->qf_index, cycle, seqnum);
+    printf("    qf_index         %" PRIu64 " (cycle %u, seqnum %u)\n", tailer->qf_index, cycle, seqnum);
     printf("    qf_buf           %p\n",   tailer->qf_buf);
     printf("      extent         %p\n",   tailer->qf_buf+tailer->qf_mmapsz);
     printf("    qf_mmapsz        %" PRIx64 "\n", tailer->qf_mmapsz);

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -340,6 +340,7 @@ K shmipc_init(K dir, K parser) {
     queue = malloc(sizeof(queue_t));
     if (queue == NULL) return krr("m fail");
     bzero(queue, sizeof(queue_t));
+    queue->roll_epoch = -1;
 
     // unsafe to use ref to q symbol here (seen it go out of scope), so dup
     queue->dirname = strdup(&dir->s[1]);
@@ -403,11 +404,12 @@ K shmipc_init(K dir, K parser) {
     munmap(queuefile_buf, queuefile_extent);
     close(queuefile_fd);
 
-    // check we loaded some rollover settings from queuefile
-    if (queue->roll_length == 0) krr("qfi roll_length fail");
-    if (queue->index_count == 0) krr("qfi index_count fail");
-    if (queue->index_spacing == 0) krr("qfi index_spacing fail");
-    if (queue->roll_format == 0) krr("qfi roll_format fail");
+    // check we loaded some rollover settings from queuefile or metadata
+    if (queue->roll_length == 0) return krr("qfi roll_length fail");
+    if (queue->index_count == 0) return krr("qfi index_count fail");
+    if (queue->index_spacing == 0) return krr("qfi index_spacing fail");
+    if (queue->roll_format == 0) return krr("qfi roll_format fail");
+    if (queue->roll_epoch == -1) return krr("qfi roll_epoch fail");
 
     // TODO check yyyymmdd
     queue->cycle2file_fn = &get_cycle_fn_yyyymmdd;

--- a/native/shmmain.c
+++ b/native/shmmain.c
@@ -24,7 +24,7 @@ int print_data = 0;
 
 K printxy(K x, K y) {
 	if (print_data) {
-		printf("%llu: ", x->j);
+		printf("[%llu] ", x->j);
 		if (y->t == KC)
 			fwrite(kC(y), sizeof(char), y->n, stdout);
 		printf("\n");
@@ -64,10 +64,10 @@ int main(const int argc, char **argv) {
 			followflag = 1;
 			break;
 		case '?':
-			fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+			fprintf(stderr, "Option '-%c' missing argument\n", optopt);
 			exit(2);
 		default:
-			fprintf(stderr, "%c??", c);
+			fprintf(stderr, "Unknown option '%c'\n", c);
 			exit(3);
 	}
 

--- a/native/shmmain.c
+++ b/native/shmmain.c
@@ -53,6 +53,7 @@ int main(const int argc, char **argv) {
 			print_data = 1;
 			break;
 		case 'i':
+			index = strtoull(optarg, NULL, 0);
 			break;
 		case 'v':
 			verboseflag = 1;

--- a/native/wire.h
+++ b/native/wire.h
@@ -127,7 +127,7 @@ void parse_wire(unsigned char* base, int lim, uint64_t index, wirecallbacks_t* c
                 break;
             case 0xA7: // INT64
                 memcpy(&padding64, p, sizeof(padding64));
-                if (wire_trace) printf(" Field %.*s = %" PRIu64 "\n", field_name_sz, field_name, padding64);
+                if (wire_trace) printf(" Field %.*s = %" PRIu64 " (uint64)\n", field_name_sz, field_name, padding64);
                 if (cbs->ptr_uint64) cbs->ptr_uint64(ev_name, ev_name_sz, p, cbs);
                 if (cbs->field_uint64) cbs->field_uint64(field_name, field_name_sz, padding64, cbs);
                 p += 8;


### PR DESCRIPTION
Add a `version` field in the queue structure to store detected version
Parse `metadata.cq4t` file to detect rollover settings, skipping the `queuefile_glob` init-time mapping
Bump Java upstream to v5.20 

fixes #11  