### PR TITLE
Refactor libchronicle shmipc callbacks

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -11,7 +11,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    - name: Prep
+      shell: bash
+      run: sudo apt install libcmocka-dev
     - name: Build
       shell: bash
       run: make -C native
+    - name: Test
+      shell: bash
+      run: make -C native test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 native/k.h
+native/test/*.to
+native/test/*.tok

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ to avoid probing the file system execessively with `stat` system calls during a 
 
 ## Bindings
 
-This repository contains command line C utilities, as well as language bindings (.so+.q) for kdb.
+This repository contains command line C utilities, `shmmain` as well as language bindings `shmipc.so` for kdb.
 Planned:
 - python
 - nodejs
@@ -68,6 +68,15 @@ The tool `shmmain` can replay, or follow, _DAILY_ or _DAILY_FAST_ queues files a
 It cannot yet use or append to index pages #1 or create a completely empty queue #15.
 
 If you can reproduce a segfault on an otherwise valid queuefile, examples would be happily recieved via. a Github Issue.
+
+
+## Unit tests
+
+To build the test suite install https://cmocka.org/
+
+    $ sudo apt install libcmocka-dev
+    $ cd native
+    $ make test
 
 ## Fuzzer & Coverage
 There is basic code coverage reporting using `clang`'s coverage suite, tested on a Mac. This uses shmmain to read and write some entries and shows line by line coverage. Try:

--- a/native/Makefile
+++ b/native/Makefile
@@ -17,15 +17,23 @@ endif
 
 ODIR=obj
 LIBS=-lm
-DEPS = k.h wire.h
+DEPS=k.h wire.h
 
-all: obj/hpet.so obj/shmipc.so obj/shmmain obj/fuzzmain
+tests := $(patsubst %.c,%.to,$(wildcard test/test*.c))
+testsok := $(patsubst %.c,%.tok,$(wildcard test/test*.c))
+all: obj/hpet.so obj/shmmain obj/shmipc.so $(tests)
 
 k.h:
 	wget https://raw.githubusercontent.com/KxSystems/kdb/master/c/c/k.h
 
 $(ODIR)/%.so: %.c $(DEPS)
 	$(CC) -o $@ $< $(CFLAGS) $(CDFLAGS)
+
+%.to: %.c $(DEPS)
+	$(CC) -o $@ $< $(CFLAGS) -lcmocka
+
+%.tok: %.to
+	$< && touch $@
 
 $(ODIR)/fuzzmain: fuzzmain.c shmipc.c mock_k.h $(DEPS)
 	$(CC) -o $@ $< $(CFLAGS) -g -O0
@@ -55,8 +63,11 @@ fuzz: $(ODIR)/shmmain.fuzz
 $(ODIR)/shmmain.fuzz: shmmain.c shmipc.c mock_k.h $(DEPS)
 	/usr/local/Cellar/afl-fuzz/2.52b/bin/afl-clang -o $@ $< $(CFLAGS) -g -O0
 
-.PHONY: clean grind coverage syms fuzz
+.PHONY: clean grind coverage syms fuzz test
+
+test: $(testsok)
 
 clean:
 	rm -f *~ core $(INCDIR)/*~ default.prof*
 	rm -Rf $(ODIR)/*
+	rm -Rf test/*.to test/*.tok

--- a/native/fuzzmain.c
+++ b/native/fuzzmain.c
@@ -132,12 +132,11 @@ int main(const int argc, char **argv) {
 		}
 	}
 
-	K parser = kss("text");
-	per(shmipc_init(dir, parser));
+	queue_t* queue = chronicle_init(dir, parser);
 
 	K cb = dl(&printxy, 2);
-	K kindex = kj(0L);
-	per(shmipc_tailer(dir,cb,kindex));
+
+	tailer_t tailer = chronicle_tailer(queue, cb, 0);
 	per(shmipc_peek(dir));
 
 	if (verboseflag) {
@@ -221,7 +220,6 @@ int main(const int argc, char **argv) {
 	r0(dir);
 	r0(parser);
 	r0(cb);
-	r0(kindex);
 
 	return 0;
 }

--- a/native/libchronicle.c
+++ b/native/libchronicle.c
@@ -1,0 +1,1234 @@
+// Copyright 2021 Tea Engineering Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define _GNU_SOURCE
+
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <glob.h>
+#include <time.h>
+
+#include "k.h"
+#include "wire.h"
+
+/**
+ * Implementation notes
+ * This code is not reentrant, nor does it create any threads, so this is not a problem.
+ * Should not be used by additional threads without external locking.
+ * Multiple processes can append and tail from a queue concurrently, and one process
+ * may read or write from multiple queues.
+ *
+ * TODO: current iteration requires a Java Chronicle-Queues appender to be writing to the same
+ * queue on a periodic timer to roll over the log files correctly and maintain the index structures.
+ *
+ * It should be possible to append to a queue from a tailer callback on same queue, so the fds
+ * and mmaps used for writing are separate to those used in recovery.
+ *
+ * Most of the appender logic is actually just the tailer logic, followed by cas write-lock.
+ * For interesting concurrency parts search 'lock_cmpxchgl' and 'mfence'.
+ *
+ * To gurantee we can read and write payloads of 'blocksize' length we map
+ * 2x blocksize each time, aligning the map offset to be a multiple of blocksize from
+ * the start of the file. If the block parser (parse_queue_block) is about to step
+ * over the buffer end, it returns asking for advance. There are two outcomes: either
+ * we are positioned in 2nd block ('overhang'), and our mmap() will advance one block
+ * completing the parse, or having tried that the parser will stop again without moving
+ * in which case we double the blocksize.
+ *
+ * The interesting caller of parse_queue_block is shmipc_peek_tailer_r, which handles
+ * splitting the index into cycle and seqnum, determinging the filenames, opening fids,
+ * repositioning the buffer and interpreting the return codes from the block parser. It
+ * consists of a while (1) loop, repeating until one of the enumerated states
+ * prevents it from doing any further work. Reasons are in tailer_state_messages and shown
+ * in the debug output. shmipc_peek_tailer_r re-uses existing generated filenames, fids
+ * and maps from previous invocations as much as possible.
+ *
+ * patch_cycles is a variable that controls compatability with Java and is only relevant
+ * when opening an old queue that may not have been written to recently. When an appender is
+ * started, it starts seeking for the write position from (highetCycle-patch_cycles),
+ * which causes a replay to occur internally and ensures that any previous cycles
+ * covered by the replay are patched up to end with an EOF marker. For symnetry, if a
+ * reader finds itself stuck at an available marker in a queuefile for a
+ * cycle < (highestCycle-patch_cycles), it is permitted to skip over the missing EOF.
+ * Java acheives something similar using less-elegant timeouts.
+ *
+ *
+ */
+
+// MetaDataKeys `header`index2index`index`roll
+
+#define MAXDATASIZE 1000 // max number of bytes we can get at once
+
+// Chronicle header special bits
+#define HD_UNALLOCATED 0x00000000
+#define HD_WORKING     0x80000000
+#define HD_METADATA    0x40000000
+#define HD_EOF         0xC0000000
+#define HD_MASK_LENGTH 0x3FFFFFFF
+#define HD_MASK_META   HD_EOF
+
+
+// function pointer typedefs - public interface
+// parsedata_f takes void* and returns custom object if any
+// appendsizeof_f tells library how many bytes required to serialise use object
+// appendwrite_f takes custom object and writes bytes to void*
+// dispatch_f takes custom object and index, delivers to application with user data
+typedef K    (*cparse_f)    (unsigned char*,int);
+typedef long (*csizeof_f)   (K);
+typedef int  (*cappend_f)   (unsigned char*,int,K);
+typedef int  (*cdispatch_f) (void*,uint64_t,K);
+
+
+// error handling
+const char* cerr_msg;
+// error handling - trigger
+int chronicle_err(const char* msg) {
+    printf("chronicle error: '%s\n", msg);
+    errno = -1;
+    cerr_msg = msg;
+    return -1;
+}
+void* chronicle_perr(const char* msg) {
+    chronicle_err(msg);
+    return (void*)NULL;
+}
+// error handling - retrieve
+const char* chronicle_strerror() {
+    return cerr_msg;
+}
+
+typedef struct {
+    unsigned char *highest_cycle;
+    unsigned char *lowest_cycle;
+    unsigned char *modcount;
+} dirlist_fields_t;
+
+// forward definition of queue
+struct queue;
+
+typedef struct tailer {
+    uint64_t          dispatch_after; // for resume support
+    int               state;
+    cdispatch_f       dispatcher;
+    void*             dispatch_ctx;
+    // to support the 'collect' operation to wait and return next item, ignoring callback
+    int               collect;
+    K                 collected_value;
+
+    int               mmap_protection; // PROT_READ etc.
+
+    // currently open queue file
+    uint64_t          qf_cycle_open;
+    char*             qf_fn;
+    struct stat       qf_statbuf;
+    int               qf_fd;
+
+    uint64_t          qf_tip; // byte position of the next header, or zero if unknown
+    uint64_t          qf_index; // seqnum of the header pointed to by qf_tip
+
+    // currently mapped region: buffer, offset (from 0 in file), size
+    unsigned char*    qf_buf;
+    uint64_t          qf_mmapoff;
+    uint64_t          qf_mmapsz;
+
+    struct queue*     queue;
+    int               handle; // opaque int for wrappers
+
+    struct tailer*    next;
+} tailer_t;
+
+typedef struct queue {
+    char*             dirname;
+    char*             hsymbolp;
+    uint              blocksize;
+    uint8_t           version;
+
+    // directory-listing.cq4t
+    char*             dirlist_name;
+    int               dirlist_fd;
+    struct stat       dirlist_statbuf;
+    unsigned char*    dirlist; // mmap base
+    dirlist_fields_t  dirlist_fields;
+
+    char*             queuefile_pattern;
+    glob_t            queuefile_glob; // last glob of data files, refreshed by poll on modcount
+
+    // values observed from directory-listing poll
+    uint64_t          highest_cycle;
+    uint64_t          lowest_cycle;
+    uint64_t          modcount;
+
+    // roll config populated from (any) queuefile header or set on creation
+    int               roll_length;
+    int               roll_epoch;
+    char*             roll_format;
+    int               index_count;
+    int               index_spacing;
+
+    int               cycle_shift;
+    uint64_t          seqnum_mask;
+
+    char* (*cycle2file_fn)(struct queue*,int);
+
+    cparse_f          parser;
+    csizeof_f         append_sizeof;
+    cappend_f         append_write;
+
+    tailer_t*         tailers;
+
+    // the appender is a shared tailer, polled by append[], with writing logic
+    // and no callback to user code for events
+    tailer_t*         appender;
+
+    int               handle; // opaque int for wrappers
+    struct queue*     next;
+} queue_t;
+
+typedef int (*datacallback_f)(unsigned char*,int,uint64_t,void* userdata);
+
+// paramaters that control behavior, not exposed for modification
+uint32_t patch_cycles = 3;
+long int qf_disk_sz = 83754496L;
+
+// globals
+char* debug = NULL;
+uint32_t pid_header = 0;
+queue_t* queue_head = NULL;
+
+// forward declarations
+void parse_dirlist(queue_t*);
+void parse_queuefile_meta(unsigned char*, int, queue_t*);
+void parse_queuefile_data(unsigned char*, int, queue_t*, tailer_t*, uint64_t);
+int chronicle_peek_tailer(queue_t*, tailer_t*);
+void chronicle_peek_queue(queue_t*);
+void chronicle_debug_tailer(queue_t*, tailer_t*);
+uint64_t chronicle_append_ts(queue_t*, K, long);
+int queuefile_init(char*, queue_t*);
+int directory_listing_reopen(queue_t*, int, int);
+
+// compare and swap, 32 bits, addressed by a 64bit pointer
+static inline uint32_t lock_cmpxchgl(unsigned char *mem, uint32_t newval, uint32_t oldval) {
+    __typeof (*mem) ret;
+    __asm __volatile ("lock; cmpxchgl %2, %1"
+    : "=a" (ret), "=m" (*mem)
+    : "r" (newval), "m" (*mem), "0" (oldval));
+    return (uint32_t) ret;
+}
+
+static inline uint32_t lock_xadd(unsigned char* mem, uint32_t val) {
+    __asm__ volatile("lock; xaddl %0, %1"
+    : "+r" (val), "+m" (*mem) // input+output
+    : // No input-only
+    : "memory"
+    );
+    return (uint32_t)val;
+}
+
+char* get_cycle_fn_yyyymmdd(queue_t* queue, int cycle) {
+    // TODO: replace with https://ideone.com/7BADb as gmtime_r leaks
+    char* buf;
+    // time_t aka long. seconds since midnight 1970
+    time_t rawtime = cycle * 60*60*24;
+    struct tm info;
+    gmtime_r(&rawtime, &info);
+
+    // tail of this buffer is overwritten by the strftime below
+    int bufsz = asprintf(&buf, "%s/yyyymmdd.cq4", queue->dirname);
+    strftime(buf+bufsz-12, 13, "%Y%m%d.cq4", &info);
+    return buf;
+}
+
+char* get_cycle_fn_yyyymmddF(queue_t* queue, int cycle) {
+    // TODO: replace with https://ideone.com/7BADb as gmtime_r leaks
+    char* buf;
+    // time_t aka long. seconds since midnight 1970
+    time_t rawtime = cycle * 60*60*24;
+    struct tm info;
+    gmtime_r(&rawtime, &info);
+
+    // tail of this buffer is overwritten by the strftime below
+    int bufsz = asprintf(&buf, "%s/yyyymmddF.cq4", queue->dirname);
+    strftime(buf+bufsz-13, 13, "%Y%m%dF.cq4", &info);
+    return buf;
+}
+
+void queue_double_blocksize(queue_t* queue) {
+    uint new_blocksize = queue->blocksize << 1;
+    printf("shmipc:  doubling blocksize from %x to %x\n", queue->blocksize, new_blocksize);
+    queue->blocksize = new_blocksize;
+}
+
+
+queue_t* chronicle_init(char* dir, cparse_f parser, csizeof_f append_sizeof, cappend_f append_write) {
+    debug = getenv("SHMIPC_DEBUG");
+    wire_trace = getenv("SHMIPC_WIRETRACE");
+
+    pid_header = (getpid() & HD_MASK_LENGTH);
+
+    if (debug) printf("shmipc: opening dir %s\n", dir);
+
+    // check if queue already open
+    queue_t* queue = queue_head;
+    while (queue != NULL) {
+        if (queue->hsymbolp == dir) return chronicle_perr("shmipc dir dupe init");
+        queue = queue->next;
+    }
+
+    // allocate struct, we'll link if all checks pass
+    queue = malloc(sizeof(queue_t));
+    if (queue == NULL) return chronicle_perr("m fail");
+    bzero(queue, sizeof(queue_t));
+    queue->roll_epoch = -1;
+
+    // unsafe to use ref here in case caller doesn't keep in scope, so dup
+    queue->dirname = strdup(dir);
+    queue->blocksize = 1024*1024; // must be a power of two (single 1 bit)
+
+    // Is this a directory
+    struct stat statbuf;
+    if (stat(queue->dirname, &statbuf) != 0) return chronicle_perr("dir stat fail");
+    if (!S_ISDIR(statbuf.st_mode)) return chronicle_perr("dir is not a directory");
+
+    // probe V4 - Can we map the directory-listing.cq4t file
+    asprintf(&queue->dirlist_name, "%s/directory-listing.cq4t", queue->dirname);
+    int x = directory_listing_reopen(queue, O_RDONLY, PROT_READ);
+    if (x != 0) {
+        if (debug) printf("shmipc: v4 dir listing: %d %s\n", x, cerr_msg);
+        free(queue->dirlist_name);
+    } else {
+        queue->version = 4;
+    }
+
+    // probe V5 - metadata.cq4t
+    asprintf(&queue->dirlist_name, "%s/metadata.cq4t", queue->dirname);
+    x = directory_listing_reopen(queue, O_RDONLY, PROT_READ);
+    if (x != 0) {
+        if (debug) printf("shmipc: v5 dir listing: %d %s\n", x, cerr_msg);
+        free(queue->dirlist_name);
+    } else {
+        queue->version = 5;
+    }
+
+    // Does queue dir contain some .cq4 files?
+    // for V5 it is OK to have empty directory
+    glob_t *g = &queue->queuefile_glob;
+    g->gl_offs = 0;
+
+    asprintf(&queue->queuefile_pattern, "%s/*.cq4", queue->dirname);
+    glob(queue->queuefile_pattern, GLOB_ERR, NULL, g);
+    if (debug) {
+        printf("shmipc: glob %zu queue files found\n", g->gl_pathc);
+        for (int i = 0; i < g->gl_pathc;i++) {
+            printf("   %s\n", g->gl_pathv[i]);
+        }
+    }
+
+    if (queue->version == 4) {
+        // For v4, we need to read a 'queue' header from any one of the datafiles to get the
+        // rollover configuration. We don't know how to generate a filename from a cycle code
+        // yet, so this needs to use the directory listing.
+
+        if (g->gl_pathc < 1) {
+            return chronicle_perr("V4 and no queue files found so cannot initialise. Set SHMIPC_INIT_CREATE to allow queue creation");
+        }
+
+        int               queuefile_fd;
+        struct stat       queuefile_statbuf;
+        uint64_t          queuefile_extent;
+        unsigned char*    queuefile_buf;
+
+        char* fn = queue->queuefile_glob.gl_pathv[0];
+        // find length of queuefile and mmap
+        if ((queuefile_fd = open(fn, O_RDONLY)) < 0) {
+            return chronicle_perr("qfi open");
+        }
+        if (fstat(queuefile_fd, &queuefile_statbuf) < 0)
+            return chronicle_perr("qfi fstat");
+
+        // only need the first block
+        queuefile_extent = queuefile_statbuf.st_size < queue->blocksize ? queuefile_statbuf.st_size : queue->blocksize;
+
+        if ((queuefile_buf = mmap(0, queuefile_extent, PROT_READ, MAP_SHARED, queuefile_fd, 0)) == MAP_FAILED)
+            return chronicle_perr("qfi mmap fail");
+
+        // we don't need a data-parser at this stage as only need values from the header
+        if (debug) printf("shmipc: parsing queuefile %s 0..%" PRIu64 "\n", fn, queuefile_extent);
+        parse_queuefile_meta(queuefile_buf, queuefile_extent, queue);
+
+        // close queuefile
+        munmap(queuefile_buf, queuefile_extent);
+        close(queuefile_fd);
+    }
+
+    // check we loaded roll settings from queuefile or metadata
+    if (queue->version == 0) return chronicle_perr("qfi version detect fail");
+    if (queue->roll_length == 0) return chronicle_perr("qfi roll_length fail");
+    if (queue->roll_format == 0) return chronicle_perr("qfi roll_format fail");
+    if (queue->roll_epoch == -1) return chronicle_perr("qfi roll_epoch fail");
+
+    // defer this until queuefile access
+    //if (queue->index_count == 0) return chronicle_err("qfi index_count fail");
+    //if (queue->index_spacing == 0) return chronicle_err("qfi index_spacing fail");
+
+    // TODO check yyyymmdd
+    if (strcmp(queue->roll_format, "yyyyMMdd") == 0) {
+        queue->cycle2file_fn = &get_cycle_fn_yyyymmdd;
+        queue->cycle_shift = 32;
+        queue->seqnum_mask = 0x00000000FFFFFFFF;
+    } else if (strcmp(queue->roll_format, "yyyyMMdd'F'") == 0) {
+        queue->cycle2file_fn = &get_cycle_fn_yyyymmddF;
+        queue->cycle_shift = 32;
+        queue->seqnum_mask = 0x00000000FFFFFFFF;
+    } else {
+        return chronicle_perr("unsupported roll_format");
+    }
+    // TODO: Logic from RollCycles.java ensures rollover occurs before we run out of index2index pages?
+    //  cycleShift = Math.max(32, Maths.intLog2(indexCount) * 2 + Maths.intLog2(indexSpacing));
+
+    // verify user-specified parser for data segments
+    if (!parser) return chronicle_perr("NULL parser");
+    if (!append_sizeof) return chronicle_perr("NULL append_sizeof");
+    if (!append_write) return chronicle_perr("NULL append_write");
+    queue->parser = parser;
+    queue->append_sizeof = append_sizeof;
+    queue->append_write = append_write;
+
+    // Good to use
+    queue->next = queue_head;
+    queue->hsymbolp = dir; // FIXME
+    queue_head = queue;
+
+    // avoids a tailer registration before we have a minimum cycle
+    chronicle_peek_queue(queue);
+    if (debug) printf("shmipc: init complete\n");
+
+    return queue;
+
+    // wip: kernel style unwinder
+//unwind_1:
+    free(queue->dirlist_name);
+    free(queue->queuefile_pattern);
+    close(queue->dirlist_fd);
+    globfree(&queue->queuefile_glob);
+    // unlink LL if entered
+    munmap(queue->dirlist, queue->dirlist_statbuf.st_size);
+//unwind_2:
+    free(queue);
+    return NULL;
+}
+
+// return codes
+//    0  awaiting at &base
+//    1  we hit working
+//    2  we hit EOF
+//    3  data extent will cross base+limit
+//    4  hit data with no data parser
+//   (7  collected value - from parse_data)
+// if any entries are read the values at basep and indexp are updated
+// if parse_data returns non-zero, we pause parsing after the current item
+int parse_queue_block(unsigned char** basep, uint64_t *indexp, unsigned char* extent, wirecallbacks_t* hcbs, datacallback_f parse_data, void* userdata) {
+    uint32_t header;
+    int sz;
+    unsigned char* base = *basep;
+    uint64_t index = *indexp;
+    int pd = 0;
+    while (!pd) {
+        if (base+4 >= extent) return 3;
+        memcpy(&header, base, sizeof(header)); // relax, fn optimised away
+        // no speculative fetches before the header is read
+        asm volatile ("mfence" ::: "memory");
+
+        if (header == HD_UNALLOCATED) {
+            if (debug) printf(" %" PRIu64 " @%p unallocated\n", index, base);
+            return 0;
+        } else if ((header & HD_MASK_META) == HD_WORKING) {
+            if (debug) printf(" @%p locked for writing by pid %d\n", base, header & HD_MASK_LENGTH);
+            return 1;
+        } else if ((header & HD_MASK_META) == HD_METADATA) {
+            sz = (header & HD_MASK_LENGTH);
+            if (debug) printf(" @%p metadata size %x\n", base, sz);
+            if (base+4+sz >= extent) return 3;
+            parse_wire(base+4, sz, 0, hcbs);
+            // EventName  header
+            //   switch to header parser
+        } else if ((header & HD_MASK_META) == HD_EOF) {
+            if (debug) printf(" @%p EOF\n", base);
+            return 2;
+        } else {
+            sz = (header & HD_MASK_LENGTH);
+            if (debug) printf(" %" PRIu64 " @%p data size %x\n", index, base, sz);
+            if (parse_data) {
+                if (base+4+sz >= extent) return 3;
+                pd = parse_data(base+4, sz, index, userdata);
+
+            } else {
+                // bail at first data message
+                return 4;
+            }
+            index++;
+            *indexp = index;
+        }
+
+        base = base + 4 + sz;
+        *basep = base;
+    }
+    return pd;
+}
+
+
+
+// return 0 to continue dispaching, 7 to signal collected item
+int parse_data_cb(unsigned char* base, int lim, uint64_t index, void* userdata) {
+    tailer_t* tailer = (tailer_t*)userdata;
+    if (debug) printf(" text: %" PRIu64 " '%.*s'\n", index, lim, base);
+
+    // prep args and fire callback
+    if (tailer->dispatcher && index > tailer->dispatch_after) {
+        K msg = tailer->queue->parser(base, lim);
+        if (debug && msg==NULL) printf("chronicle: caution at index %" PRIu64 " parse function returned NULL, skipping\n", index);
+
+        // if asked to return inline, we skip dispatcher callback
+        if (tailer->collect) {
+            tailer->collected_value = msg;
+            return 7;
+        }
+        return tailer->dispatcher(tailer->dispatch_ctx, index, msg);
+    }
+    return 0;
+}
+
+
+void handle_dirlist_ptr(char* buf, int sz, unsigned char *dptr, wirecallbacks_t* cbs) {
+    // we are preserving *pointers* within the shared directory data page
+    // we keep the underlying mmap for life of queue
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "listing.highestCycle", sz) == 0) {
+        queue->dirlist_fields.highest_cycle = dptr;
+    } else if (strncmp(buf, "listing.lowestCycle", sz) == 0) {
+        queue->dirlist_fields.lowest_cycle = dptr;
+    } else if (strncmp(buf, "listing.modCount", sz) == 0) {
+        queue->dirlist_fields.modcount = dptr;
+    }
+}
+
+void handle_dirlist_uint32(char* buf, int sz, uint32_t data, wirecallbacks_t* cbs){
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "length", sz) == 0) {
+        if (debug) printf("  v5 roll_length set to %x\n", data);
+        queue->roll_length = data;
+    }
+}
+
+void handle_dirlist_uint8(char* buf, int sz, uint8_t data, wirecallbacks_t* cbs) {
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "epoch", sz) == 0) {
+        queue->roll_epoch = data;
+    }
+}
+
+void handle_dirlist_text(char* buf, int sz, char* data, int dsz, wirecallbacks_t* cbs) {
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "format", sz) == 0) {
+        if (debug) printf("  v5 roll_format set to %.*s\n", dsz, data);
+        queue->roll_format = strndup(data, dsz);
+    }
+}
+
+void handle_qf_uint32(char* buf, int sz, uint32_t data, wirecallbacks_t* cbs){
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "length", sz) == 0) {
+        if (debug) printf(" v4 roll_length set to %x\n", data);
+        queue->roll_length = data;
+    }
+}
+
+void handle_qf_uint16(char* buf, int sz, uint16_t data, wirecallbacks_t* cbs) {
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "indexCount", sz) == 0) {
+        queue->index_count = data;
+    } else if (strncmp(buf, "indexSpacing", sz) == 0) {
+        queue->index_spacing = data;
+    }
+}
+
+void handle_qf_uint8(char* buf, int sz, uint8_t data, wirecallbacks_t* cbs) {
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "indexSpacing", sz) == 0) {
+        queue->index_spacing = data;
+    }
+}
+
+void handle_qf_text(char* buf, int sz, char* data, int dsz, wirecallbacks_t* cbs) {
+    queue_t* queue = (queue_t*)cbs->userdata;
+    if (strncmp(buf, "format", sz) == 0) {
+        queue->roll_format = strndup(data, dsz);
+    }
+}
+
+void parse_dirlist(queue_t* queue) {
+    // dirlist mmap is the size of the fstat
+    int lim = queue->dirlist_statbuf.st_size;
+    unsigned char* base = queue->dirlist;
+    uint64_t index = 0;
+
+    wirecallbacks_t cbs;
+    bzero(&cbs, sizeof(cbs));
+    cbs.ptr_uint64 = &handle_dirlist_ptr;
+    cbs.userdata = queue;
+
+    wirecallbacks_t hcbs;
+    bzero(&hcbs, sizeof(hcbs));
+    hcbs.field_uint32 = &handle_dirlist_uint32;
+    hcbs.field_uint8 = &handle_dirlist_uint8;
+    hcbs.field_char = &handle_dirlist_text;
+    hcbs.userdata = queue;
+    parse_queue_block(&base, &index, base+lim, &hcbs, &parse_wire_data, &cbs);
+}
+
+void parse_queuefile_meta(unsigned char* base, int limit, queue_t* queue) {
+    uint64_t index = 0;
+
+    wirecallbacks_t hcbs;
+    bzero(&hcbs, sizeof(hcbs));
+    hcbs.field_uint32 = &handle_qf_uint32;
+    hcbs.field_uint16 = &handle_qf_uint16;
+    hcbs.field_uint8 =  &handle_qf_uint8;
+    hcbs.field_char = &handle_qf_text;
+    hcbs.userdata = queue;
+    parse_queue_block(&base, &index, base+limit, &hcbs, NULL, NULL);
+}
+
+void chronicle_peek() {
+    queue_t *queue = queue_head;
+    while (queue != NULL) {
+        chronicle_peek_queue(queue);
+        queue = queue->next;
+    }
+}
+
+void peek_queue_modcount(queue_t* queue) {
+    // poll shared directory for modcount
+    uint64_t modcount;
+    memcpy(&modcount, queue->dirlist_fields.modcount, sizeof(modcount));
+
+    if (queue->modcount != modcount) {
+        printf("shmipc: %s modcount changed from %" PRIu64 " to %" PRIu64 "\n", queue->hsymbolp, queue->modcount, modcount);
+        // slowpath poll
+        memcpy(&queue->modcount, queue->dirlist_fields.modcount, sizeof(modcount));
+        memcpy(&queue->lowest_cycle, queue->dirlist_fields.lowest_cycle, sizeof(modcount));
+        memcpy(&queue->highest_cycle, queue->dirlist_fields.highest_cycle, sizeof(modcount));
+    }
+}
+
+void poke_queue_modcount(queue_t* queue) {
+    // push modifications to lowestCycle, highestCycle to directory-listing mmap
+    // and atomically increment the modcount
+    uint64_t modcount;
+    memcpy(queue->dirlist_fields.highest_cycle, &queue->highest_cycle, sizeof(modcount));
+    memcpy(queue->dirlist_fields.lowest_cycle, &queue->lowest_cycle, sizeof(modcount));
+    lock_xadd(queue->dirlist_fields.modcount, 1);
+    printf("shmipc: bumped modcount\n");
+}
+
+void chronicle_peek_queue(queue_t *queue) {
+    if (debug) printf("peeking at %s\n", queue->hsymbolp);
+    peek_queue_modcount(queue);
+
+    tailer_t *tailer = queue->tailers;
+    while (tailer != NULL) {
+        chronicle_peek_tailer(queue, tailer);
+
+        tailer = tailer->next;
+    }
+}
+
+// return codes exposed via. tailer-> state
+//     0   awaiting next entry
+//     1   hit working
+//     2   missing queuefile indicated, awaiting advance or creation
+//     3   fstat failed
+//     4   mmap failed (probably fatal)
+//     5   not yet polled
+//     6   queuefile at fid needs extending on disk
+//     7   a value was collected
+const char* tailer_state_messages[] = {"AWAITING_ENTRY", "BUSY", "AWAITING_QUEUEFILE", "E_STAT", "E_MMAP", "PEEK?", "EXTEND_FAIL", "COLLECTED"};
+
+int chronicle_peek_tailer_r(queue_t *queue, tailer_t *tailer) {
+    // for each cycle file { for each block { for each entry { emit }}}
+    // this method runs like a generator, suspended in the innermost
+    // iteration when we hit the end of the file and pick up at the next peek()
+    wirecallbacks_t hcbs;
+    bzero(&hcbs, sizeof(hcbs));
+
+    while (1) {
+
+        uint64_t cycle = tailer->qf_index >> queue->cycle_shift;
+        if (cycle != tailer->qf_cycle_open || tailer->qf_fn == NULL) {
+            // free fn, mmap and fid
+            if (tailer->qf_fn) {
+                free(tailer->qf_fn);
+            }
+            if (tailer->qf_buf) {
+                munmap(tailer->qf_buf, tailer->qf_mmapsz);
+                tailer->qf_buf = NULL;
+            }
+            if (tailer->qf_fd > 0) { // close the fid if open
+                close(tailer->qf_fd);
+            }
+            tailer->qf_fn = queue->cycle2file_fn(queue, cycle);
+            tailer->qf_tip = 0;
+
+            printf("shmipc: opening cycle %" PRIu64 " filename %s\n", cycle, tailer->qf_fn);
+            int fopen_flags = O_RDONLY;
+            if (tailer->mmap_protection != PROT_READ) fopen_flags = O_RDWR;
+            if ((tailer->qf_fd = open(tailer->qf_fn, fopen_flags)) < 0) {
+                printf("shmipc:  awaiting queuefile for %s open errno=%d %s\n", tailer->qf_fn, errno, strerror(errno));
+
+                // if our cycle < highCycle, permitted to skip a missing file rather than wait
+                if (cycle < queue->highest_cycle) {
+                    uint64_t skip_to_index = (cycle + 1) << queue->cycle_shift;
+                    printf("shmipc:  skipping queuefile (cycle < highest_cycle), bumping next_index from %" PRIu64 " to %" PRIu64 "\n", tailer->qf_index, skip_to_index);
+                    tailer->qf_index = skip_to_index;
+                    continue;
+                }
+                return 2;
+            }
+            tailer->qf_cycle_open = cycle;
+
+            // renew the stat
+            if (fstat(tailer->qf_fd, &tailer->qf_statbuf) < 0) return 3;
+        }
+
+        // assert: we have open fid
+
+        //                        qf_tip
+        //    file  0               v          stat.sz
+        //          [-------------#######-------]
+        //    map                 #######
+        //                        ^      ^
+        //                     mmapoff  +mmapsz
+        //                          | basep
+        //  addr               qf_buf
+        // assign mmap limit and offset from tip and blocksize
+
+        // note: blocksize may have changed, unroll this to a constant with care
+        uint64_t blocksize_mask = ~(queue->blocksize-1);
+        uint64_t mmapoff = tailer->qf_tip & blocksize_mask;
+
+        // renew stat if we would otherwise map less than 2* blocksize
+        // TODO: write needs to extend file here!
+        if (tailer->qf_statbuf.st_size - mmapoff < 2*queue->blocksize) {
+            if (debug) printf("shmmain: approaching file size limit, less than two blocks remain\n");
+            if (fstat(tailer->qf_fd, &tailer->qf_statbuf) < 0)
+                return 3;
+            // signal to extend queuefile iff we are an appending tailer
+            if (tailer->qf_statbuf.st_size - mmapoff < 2*queue->blocksize && tailer->mmap_protection != PROT_READ) {
+                return 6;
+            }
+        }
+
+        int limit = tailer->qf_statbuf.st_size - mmapoff > 2*queue->blocksize ? 2*queue->blocksize : tailer->qf_statbuf.st_size - mmapoff;
+        if (debug) printf("shmipc:  tip %" PRIu64 " -> mmapoff %" PRIu64 " size 0x%x  blocksize_mask 0x%" PRIx64 "\n", tailer->qf_tip, mmapoff, limit, blocksize_mask);
+
+        // only re-mmap if desired window has changed since last scan
+        if (tailer->qf_buf == NULL || mmapoff != tailer->qf_mmapoff || limit != tailer->qf_mmapsz) {
+            if ((tailer->qf_buf)) {
+                munmap(tailer->qf_buf, tailer->qf_mmapsz);
+                tailer->qf_buf = NULL;
+            }
+
+            tailer->qf_mmapsz = limit;
+            tailer->qf_mmapoff = mmapoff;
+            if ((tailer->qf_buf = mmap(0, tailer->qf_mmapsz, tailer->mmap_protection, MAP_SHARED, tailer->qf_fd, tailer->qf_mmapoff)) == MAP_FAILED) {
+                printf("shmipc:  mmap failed %s %" PRIx64 " size %" PRIx64 " error=%s\n", tailer->qf_fn, tailer->qf_mmapoff, tailer->qf_mmapsz, strerror(errno));
+                tailer->qf_buf = NULL;
+                return 4;
+            }
+            printf("shmipc:  mmap offset %" PRIx64 " size %" PRIx64 " base=%p extent=%p\n", tailer->qf_mmapoff, tailer->qf_mmapsz, tailer->qf_buf, tailer->qf_buf+tailer->qf_mmapsz);
+        }
+
+        unsigned char* basep = (tailer->qf_tip - tailer->qf_mmapoff) + tailer->qf_buf; // basep within mmap
+        unsigned char* basep_old = basep;
+        unsigned char* extent = tailer->qf_buf+tailer->qf_mmapsz;
+        uint64_t index = tailer->qf_index;
+
+        //    0  awaiting at &base  (pass)
+        //    1  we hit working     (pass)
+        //    2  we hit EOF         (handle)
+        //    3  data extent will cross base+limit (handle)
+        //    4  hit data with no data parser (won't happen)
+        //    7  collected item
+        // if any entries are read the values at basep and indexp are updated
+        int s = parse_queue_block(&basep, &index, extent, &hcbs, parse_data_cb, tailer);
+        //printf("shmipc: block parser result %d, shm %p to %p\n", s, basep_old, basep);
+
+        if (s == 3 && basep == basep_old) {
+            queue_double_blocksize(queue);
+        }
+
+        if (basep != basep_old) {
+            // commit result of parsing to the tailer, adjusting for the window
+            uint64_t new_tip = basep-tailer->qf_buf + tailer->qf_mmapoff;
+            if (debug) printf("shmipc:  parser moved shm %p to %p, file %" PRIu64 " -> %" PRIu64 ", index %" PRIu64 " to %" PRIu64 "\n", basep_old, basep, tailer->qf_tip, new_tip, tailer->qf_index, index);
+            tailer->qf_tip = new_tip;
+            tailer->qf_index = index;
+        }
+
+        if (s == 1 || s == 7) return s;
+
+        if (s == 0) { // awaiting at end of queuefile
+            if (cycle < queue->highest_cycle-patch_cycles) { // allowed to fast-forward
+                uint64_t skip_to_index = (cycle + 1) << queue->cycle_shift;
+                printf("shmipc:  missing EOF for queuefile (cycle < highest_cycle-patch_cycles), bumping next_index from %" PRIu64 " to %" PRIu64 "\n", tailer->qf_index, skip_to_index);
+                tailer->qf_index = skip_to_index;
+                continue;
+            }
+            return s;
+        }
+
+        if (s == 2) {
+            // we've read an EOF marker, so the next expected index is cycle++, seqnum=0
+            uint64_t eof_cycle = ((tailer->qf_index >> queue->cycle_shift) + 1) << queue->cycle_shift;
+            printf("shmipc:  hit EOF marker, setting next_index from %" PRIu64 " to %" PRIu64 "\n", tailer->qf_index, eof_cycle);
+            tailer->qf_index = eof_cycle;
+        }
+    }
+    return 0;
+}
+
+int chronicle_peek_tailer(queue_t *queue, tailer_t *tailer) {
+    return tailer->state = chronicle_peek_tailer_r(queue, tailer);
+}
+
+void chronicle_debug() {
+    printf("shmipc: open handles\n");
+
+    queue_t *current = queue_head;
+    while (current != NULL) {
+        printf(" handle              %s\n",   current->hsymbolp);
+        printf("  blocksize          %x\n",   current->blocksize);
+        printf("  version            %d\n",   current->version);
+        printf("  dirlist_name       %s\n",   current->dirlist_name);
+        printf("  dirlist_fd         %d\n",   current->dirlist_fd);
+        printf("  dirlist_sz         %" PRIu64 "\n", (uint64_t)current->dirlist_statbuf.st_size);
+        printf("  dirlist            %p\n",   current->dirlist);
+        printf("    cycle-low        %" PRIu64 "\n", current->lowest_cycle);
+        printf("    cycle-high       %" PRIu64 "\n", current->highest_cycle);
+        printf("    modcount         %" PRIu64 "\n", current->modcount);
+        printf("  queuefile_pattern  %s\n",   current->queuefile_pattern);
+        printf("    cycle_shift      %d\n",   current->cycle_shift);
+        printf("    roll_epoch       %d\n",   current->roll_epoch);
+        printf("    roll_length (ms) %d\n",   current->roll_length);
+        printf("    roll_format      %s\n",   current->roll_format);
+        printf("    index_count      %d\n",   current->index_count);
+        printf("    index_spacing    %d\n",   current->index_spacing);
+
+        printf("  tailers:\n");
+        tailer_t *tailer = current->tailers; // shortcut to save both collections
+        while (tailer != NULL) {
+            chronicle_debug_tailer(current, tailer);
+            tailer = tailer->next;
+        }
+        printf("  appender:\n");
+        if (current->appender)
+            chronicle_debug_tailer(current, current->appender);
+
+        current = current->next;
+    }
+}
+
+void chronicle_debug_tailer(queue_t* queue, tailer_t* tailer) {
+    const char* state_text = tailer_state_messages[tailer->state];
+    printf("    dispatcher       %p\n",   tailer->dispatcher);
+    uint cycle = tailer->dispatch_after >> queue->cycle_shift;
+    uint seqnum = tailer->dispatch_after & queue->seqnum_mask;
+    printf("    dispatch_after   %" PRIu64 " (cycle %u, seqnum %u)\n", tailer->dispatch_after, cycle, seqnum);
+    printf("    state            %d - %s\n", tailer->state, state_text);
+    printf("    qf_fn            %s\n",   tailer->qf_fn);
+    printf("    qf_fd            %d\n",   tailer->qf_fd);
+    printf("    qf_statbuf_sz    %" PRIu64 "\n", (uint64_t)tailer->qf_statbuf.st_size);
+    printf("    qf_tip           %" PRIu64 "\n", tailer->qf_tip);
+    cycle = tailer->qf_index >> queue->cycle_shift;
+    seqnum = tailer->qf_index & queue->seqnum_mask;
+    printf("    qf_index         %" PRIu64 " (cycle %u, seqnum %u)\n", tailer->qf_index, cycle, seqnum);
+    printf("    qf_buf           %p\n",   tailer->qf_buf);
+    printf("      extent         %p\n",   tailer->qf_buf+tailer->qf_mmapsz);
+    printf("    qf_mmapsz        %" PRIx64 "\n", tailer->qf_mmapsz);
+    printf("    qf_mmapoff       %" PRIx64 "\n", tailer->qf_mmapoff);
+}
+
+uint64_t chronicle_append(queue_t *queue, K msg) {
+    return chronicle_append_ts(queue,msg,0);
+}
+
+uint64_t chronicle_append_ts(queue_t *queue, K msg, long ms) {
+    if (queue == NULL) return chronicle_err("queue is NULL");
+
+    // Appending logic
+    // 0) catch up to the end of the current file.
+    //   if hit EOF then we need to wait for creation of next file, poll modcount
+    //   then try opening filehandle
+    // Else we may be only writer
+    // a) determine if we need to roll to a new file - other writers may be idle
+    //     call gtod and calculate current cycle
+    //
+    //    - CAS loop to write EOF marker
+    //     create new queue file
+    //     update maxcycle and then increment modcount
+    // or
+    // b) write to current file
+    //     Is this entry indexable?
+    //       Is the index currently full
+    //     Write Entry
+    //        if mod % index, write back to index
+    //        if index full, write new index page, write back to index2index
+    //        when update index page, then write data
+    //   Before write, CAS operation to put working indicator on last entry
+    //    if fail, loop waiting for unlock. If EOF then fail is broken, retry
+    //    if data or index, skip over them and attempt again on newest page
+
+    // caution: encodecheck may tweak blocksize, do not redorder below shmipc_peek_tailer
+    long write_sz = queue->append_sizeof(msg);
+    if (write_sz < 0) return 0;
+    if (write_sz > HD_MASK_META) return chronicle_err("`shm msg sz > 30bit");
+    while (write_sz > queue->blocksize)
+        queue_double_blocksize(queue);
+
+    // refresh highest and lowest, allowing our appender to follow another appender
+    peek_queue_modcount(queue);
+
+    // build a special tailer with the protection bits and file descriptor set to allow
+    // writing.
+    if (queue->appender == NULL) {
+        tailer_t* tailer = malloc(sizeof(tailer_t));
+        if (tailer == NULL) return chronicle_err("am fail");
+        bzero(tailer, sizeof(tailer_t));
+
+        // compat: writers do an extended lookback to patch missing EOFs
+        tailer->qf_index = (queue->highest_cycle - patch_cycles) << queue->cycle_shift;
+        tailer->dispatcher = NULL;
+        tailer->state = 5;
+        tailer->mmap_protection = PROT_READ | PROT_WRITE;
+
+        queue->appender = tailer;
+
+        // re-open directory-listing mapping in read-write mode
+        int x = directory_listing_reopen(queue, O_RDWR, PROT_READ | PROT_WRITE);
+        if (x != 0) {
+            printf("shmipc: rw dir listing %d %s\n", x, cerr_msg);
+            return -1;
+        }
+        if (debug) printf("shmipc: appender created\n");
+    }
+    tailer_t* appender = queue->appender;
+
+
+    // if given a clock, use this to switch cycle
+    // which may be higher that maxCycle, in which case we need to poke the directory-listing
+    // TODO: move inside write loop to trigger EOF
+    if (ms > 0) {
+        uint64_t cyc = (ms - queue->roll_epoch) / queue->roll_length;
+        if (cyc != appender->qf_index >> queue->cycle_shift) {
+            printf("shmipc: appender setting cycle from timestamp: current %" PRIu64 " proposed %" PRIu64 "\n", appender->qf_index >> queue->cycle_shift, cyc);
+            appender->qf_index = cyc << queue->cycle_shift;
+        }
+    }
+
+    // poll the appender
+    while (1) {
+        int r = chronicle_peek_tailer(queue, appender);
+        // TODO: 2nd call defensive to ensure 1 whole blocksize is available to put
+        r = chronicle_peek_tailer(queue, appender);
+        if (debug) printf("shmipc: writeloop appender in state %d\n", r);
+
+        if (r == 2) {
+            // our cycle is pointing to a queuefile that does not exist
+            // as we are writer, create it with temporary filename, atomically
+            // move it to the desired name, then bump the global highest_cycle
+            // value if rename succeeded
+            char* fn_buf;
+            asprintf(&fn_buf, "%s.%d.tmp", appender->qf_fn, pid_header);
+
+            // if queuefile_init fails via. krr, re-throw the error and abort the write
+            if (queuefile_init(fn_buf, queue) != 0) return -1;
+
+            if (rename(fn_buf, appender->qf_fn) != 0) {
+                // rename failed, maybe raced with another writer, delay and try again
+                printf("shmipc: create queuefile %s failed at rename, errno %d\n", fn_buf, errno);
+                sleep(1);
+                continue;
+            }
+            printf("renamed %s to %s\n", fn_buf, appender->qf_fn);
+            free(fn_buf);
+
+            // rename worked, we can now re-try the peek_tailer
+            continue;
+        }
+
+        if (r == 6) {
+            // current queuefile has less than two blocks remaining, needs extending
+            // should the extend fail, we are having disk issues, wait until fixed
+            uint64_t extend_to = appender->qf_statbuf.st_size + qf_disk_sz;
+            if (lseek(appender->qf_fd, extend_to - 1, SEEK_SET) == -1) {
+                printf("shmmain: extend queuefile %s failed at lseek: %s\n", appender->qf_fn, strerror(errno));
+                sleep(1);
+                continue;
+            }
+            if (write(appender->qf_fd, "", 1) != 1) {
+                printf("shmmain: extend queuefile %s failed at write: %s\n", appender->qf_fn, strerror(errno));
+                sleep(1);
+                continue;
+            }
+            printf("shmmain: extended queuefile %s to %" PRIu64 " bytes\n", appender->qf_fn, extend_to);
+            continue;
+        }
+
+        // If the tailer returns 0, we are all set pointing to the next unwritten entry.
+        // if we write to qf_buf and the state is not zero we'll hit sigbus etc, so sleep
+        // and wait for availability.
+        if (r != 0) {
+            printf("shmipc: Cannot write in state %d, sleeping\n", r);
+            sleep(1);
+            continue;
+        }
+
+        uint32_t msz = write_sz;
+        if ((appender->qf_tip - appender->qf_mmapoff) + msz > appender->qf_mmapsz) {
+            printf("aborting on bug: write would segfault buffer!\n");
+            abort();
+        }
+
+        // Since appender->buf is pointing at the queue head, so we can
+        // LOCK CMPXCHG the working bit directly. If the cas failed, another writer
+        // has beaten us to it, we sleep poll the tailer and try again
+        // If the file has gone EOF, we re-visit the tailer logic which will adjust
+        // the maps and switch to the new file.
+
+        // Note that we do not extended qf_buf or qf_index after the write. Let the
+        // tailer log handle the entry we've just written in the normal way, since that will
+        // adjust the buffer window/mmap for us.
+        unsigned char* ptr = (appender->qf_tip - appender->qf_mmapoff) + appender->qf_buf;
+        uint32_t ret = lock_cmpxchgl(ptr, HD_UNALLOCATED, HD_WORKING);
+
+        // cmpxchg returns the original value in memory, so we can tell if we succeeded
+        // by looking for HD_UNALLOCATED. If we read a working bit or finished size, we lost.
+        if (ret == HD_UNALLOCATED) {
+            asm volatile ("mfence" ::: "memory");
+
+            // Java does not patch EOF on prev files if it is down during the roll, it
+            // just starts a new file. As a workaround their readers 'timeout' the wait for EOF
+            // if a higher cycle is known for the queue. I'd like to be as correct as possible, so
+            // we'll patch missing EOFs during our writes if we hold the lock. This will nudge on any
+            // readers who haven't noticed the roll.
+            if (appender->qf_index < queue->highest_cycle << queue->cycle_shift) {
+                printf("shmipc: got write lock, but about to write to queuefile < maxcycle, writing EOF\n");
+                uint32_t header = HD_EOF;
+                memcpy(ptr, &header, sizeof(header));
+                continue; // retry write in next queuefile
+            }
+
+            queue->append_write(ptr+4, msz, msg);
+
+            asm volatile ("mfence" ::: "memory");
+            uint32_t header = msz & HD_MASK_LENGTH;
+            memcpy(ptr, &header, sizeof(header));
+
+            break;
+        }
+
+        printf("shmipc: write lock failed, peeking again\n");
+        sleep(1);
+    }
+
+    // if we've rolled a new file,inform listeners by bumping modcount
+    uint64_t cyc = appender->qf_index >> queue->cycle_shift;
+    if (cyc > queue->highest_cycle) {
+        queue->highest_cycle = cyc;
+        poke_queue_modcount(queue);
+    }
+
+    if (debug) printf("shmipc: wrote %lld bytes as index %" PRIu64 "\n", msg->n, appender->qf_index);
+
+    return appender->qf_index;
+}
+
+tailer_t* chronicle_tailer(queue_t *queue, cdispatch_f dispatcher, void* dispatch_ctx, uint64_t index) {
+    if (queue == NULL) return chronicle_perr("queue is not valid");
+    if (dispatcher == NULL) return chronicle_perr("dispatcher is not a callback");
+
+    // decompose index into cycle (file) and seqnum within file
+    int cycle = index >> queue->cycle_shift;
+    int seqnum = index & queue->seqnum_mask;
+
+    printf("shmipc: tailer added index=%" PRIu64 " (cycle=%d seqnum=%d)\n", index, cycle, seqnum);
+    if (cycle < queue->lowest_cycle) {
+        index = queue->lowest_cycle << queue->cycle_shift;
+    }
+    if (cycle > queue->highest_cycle) {
+        index = queue->highest_cycle << queue->cycle_shift;
+    }
+
+    // allocate struct, we'll link if all checks pass
+    tailer_t* tailer = malloc(sizeof(tailer_t));
+    if (tailer == NULL) return chronicle_perr("tm fail");
+    bzero(tailer, sizeof(tailer_t));
+
+    tailer->dispatch_after = index - 1;
+    tailer->qf_index = index & ~queue->seqnum_mask; // start replay from first entry in file
+    tailer->dispatcher = dispatcher;
+    tailer->dispatch_ctx = dispatch_ctx;
+    tailer->state = 5;
+    tailer->mmap_protection = PROT_READ;
+
+    tailer->next = queue->tailers; // linked list
+    queue->tailers = tailer;
+
+    tailer->queue = queue; // parent pointer
+    return tailer;
+}
+
+K chronicle_collect(tailer_t *tailer) {
+    if (tailer == NULL) return chronicle_perr("null tailer");
+    tailer->collect = 1;
+
+    uint64_t delaycount = 0;
+    peek_queue_modcount(tailer->queue);
+    while (1) {
+        int r = chronicle_peek_tailer(tailer->queue, tailer);
+        if (debug) printf("collect value returns %d and object %p\n", r, tailer->collected_value);
+        if (r == 7) {
+            break;
+        }
+        if (delaycount++ >> 20) usleep(delaycount >> 20);
+    }
+    K x = tailer->collected_value;
+    tailer->collected_value = NULL;
+    return x;
+}
+
+void chronicle_tailer_close(tailer_t* tailer) {
+    if (tailer->qf_fn) { // if next filename cached...
+        free(tailer->qf_fn);
+    }
+    if (tailer->qf_buf) { // if mmap() open...
+        munmap(tailer->qf_buf, tailer->qf_mmapsz);
+    }
+    if (tailer->qf_fd) { // if open() open...
+        close(tailer->qf_fd);
+    }
+    free(tailer);
+}
+
+int chronicle_close(queue_t* queue_delete) {
+    if (queue_delete == NULL) return chronicle_err("queue is NULL");
+
+    // check if queue already open
+    queue_t **parent = &queue_head; // pointer to a queue_t pointer
+    queue_t *queue = queue_head;
+
+    while (queue != NULL) {
+        if (queue == queue_delete) {
+            *parent = queue->next; // unlink
+
+            // delete tailers
+            tailer_t *tailer = queue->tailers; // shortcut to save both collections
+            while (tailer != NULL) {
+                tailer_t* next_tmp = tailer->next;
+                chronicle_tailer_close(tailer);
+                tailer = next_tmp;
+            }
+            queue->tailers = NULL;
+
+            if (queue->appender) chronicle_tailer_close(queue->appender);
+
+            // kill queue
+            munmap(queue->dirlist, queue->dirlist_statbuf.st_size);
+            close(queue->dirlist_fd);
+            free(queue->dirlist_name);
+            free(queue->dirname);
+            free(queue->queuefile_pattern);
+            free(queue->roll_format);
+            globfree(&queue->queuefile_glob);
+            free(queue);
+
+            return 0;
+        }
+        parent = &queue->next;
+        queue = queue->next;
+    }
+    return chronicle_err("chronicle_close: queue already closed");
+}
+
+int queuefile_init(char* fn, queue_t* queue) {
+    int fd;
+    int mode = 0777;
+
+    printf("Creating %s\n", fn);
+
+    // open/create the output file
+    if ((fd = open(fn, O_RDWR | O_CREAT | O_TRUNC, mode)) < 0) {
+        printf("can't create %s for writing", fn);
+        return chronicle_err("shmipc: create tmp queuefile err");
+    }
+
+    // go to the location corresponding to the last byte
+    if (lseek(fd, qf_disk_sz - 1, SEEK_SET) == -1) {
+        return chronicle_err("shmipc: lseek error");
+    }
+
+    // write a dummy byte at the last location
+    if (write(fd, "", 1) != 1) {
+        return chronicle_err("shmipc: write error");
+    }
+
+    // TODO: write header
+    // TODO: write index2index
+    printf("Created %s\n", fn);
+
+    close(fd);
+    return 0;
+}
+
+int directory_listing_reopen(queue_t* queue, int open_flags, int mmap_prot) {
+
+    if ((queue->dirlist_fd = open(queue->dirlist_name, open_flags)) < 0) {
+        return chronicle_err("dirlist open fail");
+    }
+
+    // find size of dirlist and mmap
+    if (fstat(queue->dirlist_fd, &queue->dirlist_statbuf) < 0)
+        return chronicle_err("dirlist fstat");
+    if ((queue->dirlist = mmap(0, queue->dirlist_statbuf.st_size, mmap_prot, MAP_SHARED, queue->dirlist_fd, 0)) == MAP_FAILED)
+        return chronicle_err("dirlist mmap fail");
+
+    if (debug) printf("shmipc: parsing dirlist\n");
+    parse_dirlist(queue);
+
+    // check the polled fields in header section were all resolved to pointers within the map
+    if (queue->dirlist_fields.highest_cycle == NULL || queue->dirlist_fields.lowest_cycle == NULL ||
+        queue->dirlist_fields.modcount == NULL) {
+        return chronicle_err("dirlist parse hdr ptr fail");
+    }
+    return 0;
+}

--- a/native/mock_k.h
+++ b/native/mock_k.h
@@ -19,6 +19,8 @@
 // as valgrind can't hook the individual allocations to record the stack.
 //
 
+#define KERR -128
+
 // globals
 int kxx_errno = 0;
 char* kxx_msg = NULL;

--- a/native/shmipc.c
+++ b/native/shmipc.c
@@ -1,4 +1,4 @@
-// Copyright 2018 Tea Engineering Ltd.
+// Copyright 2021 Tea Engineering Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,255 +12,80 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//
+// This file builds a shared-object "shmipc" for easy integration of
+// libchronicle with the KDB/q intepreter from Kx.
+// It does not incorporate mock_k.h as the real
+// implementation of those symbols is provided by the KDB runtime.
+//
+// The KDB calling convention requires all functions to return a K object
+// and all arguments are provided as K objects, so these wrappers take care
+// of that.
+//
+// We provide a simple way to select the protocol of the queue, either
+//  "text", "raw", "kx" or "wire".
+//
+// *text* writes bytes directly to the queue data messages, requiring and
+// returning messages bytes as characters in type KG
+//
+// *raw* writes and returns byte arrays of type KB - this is compatable with
+// anything Java might produce, however will require some unpickling.
+//
+// *kx* uses d9/b9 to use KDB's built in serialisers. This is your best bet
+// if serialising between two KDB processes, or if you want to use Kx objects
+// tables etc. Remember the max data size is 1GB.
+//
+// *wire* uses wire.h to write some KDB values using the Chronicle-Wire
+// "self-describing" format. This limits what you can do but is easiest for
+// cross-platform compatability.
+//
+//  see bindings/kdb for .q harnesses and tests
+
 #define _GNU_SOURCE
-
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <errno.h>
-#include <string.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <glob.h>
-#include <time.h>
-
-#include "k.h"
-#include "wire.h"
-
-/**
- * Implementation notes
- * This code is not reentrant, but there is only one main thread, so this is not a problem.
- * Should not be used by additional threads without external locking.
- * Multiple processes can append and tail from a queue concurrently, and one process
- * may read or write from multiple queues.
- *
- * TODO: current iteration requires a Java Chronicle-Queues appender to be writing to the same
- * queue on a periodic timer to roll over the log files correctly and maintain the index structures.
- *
- * It should be possible to append to a queue from a tailer callback on same queue, so the fds
- * and mmaps used for writing are separate to those used in recovery.
- *
- * Most of the appender logic is actually just the tailer logic, followed by cas write-lock.
- * For interesting concurrency parts search 'lock_cmpxchgl' and 'mfence'.
- *
- * To gurantee we can read and write payloads of 'blocksize' length we map
- * 2x blocksize each time, aligning the map offset to be a multiple of blocksize from
- * the start of the file. If the block parser (parse_queue_block) is about to step
- * over the buffer end, it returns asking for advance. There are two outcomes: either
- * we are positioned in 2nd block ('overhang'), and our mmap() will advance one block
- * completing the parse, or having tried that the parser will stop again without moving
- * in which case we double the blocksize.
- *
- * The interesting caller of parse_queue_block is shmipc_peek_tailer_r, which handles
- * splitting the index into cycle and seqnum, determinging the filenames, opening fids,
- * repositioning the buffer and interpreting the return codes from the block parser. It
- * consists of a while (1) loop, repeating until one of the enumerated states
- * prevents it from doing any further work. Reasons are in tailer_state_messages and shown
- * in the debug output. shmipc_peek_tailer_r re-uses existing generated filenames, fids
- * and maps from previous invocations as much as possible.
- *
- * patch_cycles is a variable that controls compatability with Java and is only relevant
- * when opening an old queue that may not have been written to recently. When an appender is
- * started, it starts seeking for the write position from (highetCycle-patch_cycles),
- * which causes a replay to occur internally and ensures that any previous cycles
- * covered by the replay are patched up to end with an EOF marker. For symnetry, if a
- * reader finds itself stuck at an available marker in a queuefile for a
- * cycle < (highestCycle-patch_cycles), it is permitted to skip over the missing EOF.
- * Java acheives something similar using less-elegant timeouts.
- *
- *
- */
-
-// MetaDataKeys `header`index2index`index`roll
-
-#define MAXDATASIZE 1000 // max number of bytes we can get at once
-
-// Chronicle header special bits
-#define HD_UNALLOCATED 0x00000000
-#define HD_WORKING     0x80000000
-#define HD_METADATA    0x40000000
-#define HD_EOF         0xC0000000
-#define HD_MASK_LENGTH 0x3FFFFFFF
-#define HD_MASK_META   HD_EOF
-
 #define KERR -128
 
-// function pointer typedefs
-struct queue;
-typedef int (*parsedata_f)(unsigned char*,int,uint64_t,void* userdata);
-typedef int (*appenddata_f)(unsigned char*,int,int*,K);
-typedef K (*encodecheck_f)(struct queue*,K);
+#include <stdarg.h>
+#include <ctype.h>
+#include <libchronicle.c>
 
-typedef struct {
-    unsigned char *highest_cycle;
-    unsigned char *lowest_cycle;
-    unsigned char *modcount;
-} dirlist_fields_t;
-
-typedef struct tailer {
-    uint64_t          dispatch_after; // for resume support
-    int               state;
-    K                 callback;
-    // to support the 'collect' operation to wait and return next item, ignoring callback
-    int               collect;
-    K                 collected_value;
-
-    int               mmap_protection; // PROT_READ etc.
-
-    // currently open queue file
-    uint64_t          qf_cycle_open;
-    char*             qf_fn;
-    struct stat       qf_statbuf;
-    int               qf_fd;
-
-    uint64_t          qf_tip; // byte position of the next header, or zero if unknown
-    uint64_t          qf_index; // seqnum of the header pointed to by qf_tip
-
-    // currently mapped region: buffer, offset (from 0 in file), size
-    unsigned char*    qf_buf;
-    uint64_t          qf_mmapoff;
-    uint64_t          qf_mmapsz;
-
-    struct queue*     queue;
-    int               handle;
-
-    struct tailer*    next;
-} tailer_t;
-
-typedef struct queue {
-    char*             dirname;
-    char*             hsymbolp;
-    uint              blocksize;
-    uint8_t           version;
-
-    // directory-listing.cq4t
-    char*             dirlist_name;
-    int               dirlist_fd;
-    struct stat       dirlist_statbuf;
-    unsigned char*    dirlist; // mmap base
-    dirlist_fields_t  dirlist_fields;
-
-    char*             queuefile_pattern;
-    glob_t            queuefile_glob; // last glob of data files, refreshed by poll on modcount
-
-    // values observed from directory-listing poll
-    uint64_t          highest_cycle;
-    uint64_t          lowest_cycle;
-    uint64_t          modcount;
-
-    // roll config populated from (any) queuefile header
-    int               roll_length;
-    int               roll_epoch;
-    char*             roll_format;
-    int               index_count;
-    int               index_spacing;
-
-    int               cycle_shift;
-    uint64_t          seqnum_mask;
-
-    char* (*cycle2file_fn)(struct queue*,int);
-
-    parsedata_f       parser;
-    appenddata_f      encoder;
-    encodecheck_f     encodecheck;
-
-    tailer_t*         tailers;
-
-    // the appender is a shared tailer, polled by append[], with writing logic
-    // and no callback to user code for events
-    tailer_t*         appender;
-
-    struct queue*     next;
-} queue_t;
-
-// paramaters that control behavior, not exposed for modification
-uint32_t patch_cycles = 3;
-long int qf_disk_sz = 83754496L;
-
-// globals
-char* debug = NULL;
-uint32_t pid_header = 0;
-queue_t* queue_head = NULL;
+// Usual KDB indirection
+// return handle integer to index structure
 tailer_t** tailer_handles;
 int tailer_handles_count = 0;
 
-// forward declarations
-void parse_dirlist(queue_t*);
-void parse_queuefile_meta(unsigned char*, int, queue_t*);
-void parse_queuefile_data(unsigned char*, int, queue_t*, tailer_t*, uint64_t);
-int shmipc_peek_tailer(queue_t*, tailer_t*);
-void shmipc_peek_queue(queue_t*);
-void shmipc_debug_tailer(queue_t*, tailer_t*);
-K shmipc_append_ts(K, K, K);
-K queuefile_init(char*, queue_t*);
-K directory_listing_reopen(queue_t*, int, int);
 
-// compare and swap, 32 bits, addressed by a 64bit pointer
-static inline uint32_t lock_cmpxchgl(unsigned char *mem, uint32_t newval, uint32_t oldval) {
-    __typeof (*mem) ret;
-    __asm __volatile ("lock; cmpxchgl %2, %1"
-    : "=a" (ret), "=m" (*mem)
-    : "r" (newval), "m" (*mem), "0" (oldval));
-    return (uint32_t) ret;
-}
-
-static inline uint32_t lock_xadd(unsigned char* mem, uint32_t val) {
-    __asm__ volatile("lock; xaddl %0, %1"
-    : "+r" (val), "+m" (*mem) // input+output
-    : // No input-only
-    : "memory"
-    );
-    return (uint32_t)val;
-}
-
-char* get_cycle_fn_yyyymmdd(queue_t* queue, int cycle) {
-    // TODO: replace with https://ideone.com/7BADb as gmtime_r leaks
-    char* buf;
-    // time_t aka long. seconds since midnight 1970
-    time_t rawtime = cycle * 60*60*24;
-    struct tm info;
-    gmtime_r(&rawtime, &info);
-
-    // tail of this buffer is overwritten by the strftime below
-    int bufsz = asprintf(&buf, "%s/yyyymmdd.cq4", queue->dirname);
-    strftime(buf+bufsz-12, 13, "%Y%m%d.cq4", &info);
-    return buf;
-}
-
-char* get_cycle_fn_yyyymmddF(queue_t* queue, int cycle) {
-    // TODO: replace with https://ideone.com/7BADb as gmtime_r leaks
-    char* buf;
-    // time_t aka long. seconds since midnight 1970
-    time_t rawtime = cycle * 60*60*24;
-    struct tm info;
-    gmtime_r(&rawtime, &info);
-
-    // tail of this buffer is overwritten by the strftime below
-    int bufsz = asprintf(&buf, "%s/yyyymmddF.cq4", queue->dirname);
-    strftime(buf+bufsz-13, 13, "%Y%m%dF.cq4", &info);
-    return buf;
-}
-
-void queue_double_blocksize(queue_t* queue) {
-    uint new_blocksize = queue->blocksize << 1;
-    printf("shmipc:  doubling blocksize from %x to %x\n", queue->blocksize, new_blocksize);
-    queue->blocksize = new_blocksize;
-}
-
-// return 0 to continue dispaching, 7 to signal collected item
-int dispatch_callback(tailer_t* tailer, uint64_t index, K obj) {
-    K arg = knk(2, kj(index), obj);
-    if (tailer->collect) {
-        tailer->collected_value = arg;
-        return 7;
+K parse_kx(unsigned char* base, int lim) {
+    // prep args and fire callback
+    K msg = ktn(KG, lim);
+    memcpy((char*)msg->G0, base, lim);
+    int ok = okx(msg);
+    if (ok) {
+        K out = d9(msg);
+        r0(msg);
+        return out;
+    } else {
+        if (debug) printf("shmipc: caution index okx returned bytes !ok, skipping\n");
+        return NULL;
     }
+    return 0;
+}
 
-    K r = dot(tailer->callback, arg);
+// the encoding via. b9 happens in shmipc_append, so here we just
+// write the bytes
+int append_kx(unsigned char* base, int lim, K msg) {
+    memcpy(base, (char*)msg->G0, msg->n);
+    return msg->n;
+}
+
+long sizeof_kx(K msg) {
+    if (debug) printf("shmipc: kx persist needs %lld bytes\n", msg->n);
+    return msg->n;
+}
+
+int tailer_callback_kx(void* dispatch_ctx, uint64_t index, K msg) {
+    K arg = knk(2, kj(index), msg);
+
+    K r = dot((K)dispatch_ctx, arg);
     r0(arg);
     if (r == NULL) {
         printf(" shmipc: caution, error signalled by callback (returned NULL)\n");
@@ -272,658 +97,33 @@ int dispatch_callback(tailer_t* tailer, uint64_t index, K obj) {
     return 0;
 }
 
-int parse_data_text(unsigned char* base, int lim, uint64_t index, void* userdata) {
-    tailer_t* tailer = (tailer_t*)userdata;
-    if (debug) printf(" text: %" PRIu64 " '%.*s'\n", index, lim, base);
-
-    // prep args and fire callback
-    if (tailer->callback && index > tailer->dispatch_after) {
-        K msg = ktn(KC, lim); // don't free this, handed over to q interp
-        memcpy((char*)msg->G0, base, lim);
-        return dispatch_callback(tailer, index, msg);
-    }
-    return 0;
-}
-
-int append_data_text(unsigned char* base, int lim, int* sz, K msg) {
-    return 0;
-}
-
-K append_check_text(queue_t* queue, K msg) {
-    if (msg->t != KC) return krr("msg must be KC");
-    while (msg->n > queue->blocksize)
-        queue_double_blocksize(queue);
-    return msg;
-}
-
-int parse_data_kx(unsigned char* base, int lim, uint64_t index, void* userdata) {
-    tailer_t* tailer = (tailer_t*)userdata;
-
-    // prep args and fire callback
-    if (tailer->callback && index > tailer->dispatch_after) {
-        K msg = ktn(KG, lim);
-        memcpy((char*)msg->G0, base, lim);
-        int ok = okx(msg);
-        if (ok) {
-            K out = d9(msg);
-            r0(msg);
-            return dispatch_callback(tailer, index, out);
-        } else {
-            if (debug) printf("shmipc: caution index %" PRIu64 " bytes !ok as kx, skipping\n", index);
-        }
-    }
-    return 0;
-}
-
-int append_data_kx(unsigned char* base, int lim, int* sz, K msg) {
-    r0(msg);
-    return 0;
-}
-
-K append_check_kx(queue_t* queue, K msg) {
-    K r = b9(3, msg);
-    if (r == NULL) {
-        printf("shmipc: failed to serialise msg using b9 - aborting\n");
-        abort();
-    }
-    if (debug) printf("shmipc: kx persist needs %lld bytes\n", r->n);
-    while (r->n > queue->blocksize)
-        queue_double_blocksize(queue);
-    return r;
-}
-
 K shmipc_init(K dir, K parser) {
     if (dir->t != -KS) return krr("dir is not symbol");
     if (dir->s[0] != ':') return krr("dir is not symbol handle (starts with :)");
-    if (parser->t != -KS) return krr("parser is not symbol");
 
-    debug = getenv("SHMIPC_DEBUG");
-    wire_trace = getenv("SHMIPC_WIRETRACE");
+    // if (strncmp(parser->s, "text", parser->n) == 0) {
+    //     queue->parser = &parse_text;
+    //     queue->encoder = &append_text;
+    //     queue->encodecheck = &sizeof_text;
+    // } else if (strncmp(parser->s, "kx", parser->n) == 0) {
+    //     queue->parser = &parse_kx;
+    //     queue->encoder = &append_kx;
+    //     queue->encodecheck = &sizeof_kx;
+    // } else {
+    //     return krr("bad format: supports `kx and `text");
+    // }
 
-    pid_header = (getpid() & HD_MASK_LENGTH);
-
-    printf("shmipc: opening dir %s format %s\n", dir->s, parser->s);
-
-    // check if queue already open
-    queue_t* queue = queue_head;
-    while (queue != NULL) {
-        if (queue->hsymbolp == dir->s) return krr("shmipc dir dupe init");
-        queue = queue->next;
-    }
-
-    // allocate struct, we'll link if all checks pass
-    queue = malloc(sizeof(queue_t));
-    if (queue == NULL) return krr("m fail");
-    bzero(queue, sizeof(queue_t));
-    queue->roll_epoch = -1;
-
-    // unsafe to use ref to q symbol here (seen it go out of scope), so dup
-    queue->dirname = strdup(&dir->s[1]);
-    queue->blocksize = 1024*1024; // must be a power of two (single 1 bit)
-
-    // Is this a directory
-    struct stat statbuf;
-    if (stat(queue->dirname, &statbuf) != 0) return krr("stat fail");
-    if (!S_ISDIR(statbuf.st_mode)) return krr("dir is not a directory");
-
-    // probe V4 - Can we map the directory-listing.cq4t file
-    asprintf(&queue->dirlist_name, "%s/directory-listing.cq4t", queue->dirname);
-    K x = ee(directory_listing_reopen(queue, O_RDONLY, PROT_READ));
-    if (x && x->t == KERR && x->s) {
-        printf("shmipc: v4 dir listing %p %s\n", x, x->s);
-        free(queue->dirlist_name);
-        r0(x);
-    } else {
-        queue->version = 4;
-    }
-
-    // probe V5 - metadata.cq4t
-    asprintf(&queue->dirlist_name, "%s/metadata.cq4t", queue->dirname);
-    x = ee(directory_listing_reopen(queue, O_RDONLY, PROT_READ));
-    if (x && x->t == KERR && x->s) {
-        printf("shmipc: v5 dir listing %p %s\n", x, x->s);
-        free(queue->dirlist_name);
-        r0(x);
-    } else {
-        queue->version = 5;
-    }
-
-    // Does queue dir contain some .cq4 files?
-    // for V5 it is OK to have empty directory
-    glob_t *g = &queue->queuefile_glob;
-    g->gl_offs = 0;
-
-    asprintf(&queue->queuefile_pattern, "%s/*.cq4", queue->dirname);
-    glob(queue->queuefile_pattern, GLOB_ERR, NULL, g);
-    if (debug) {
-        printf("shmipc: glob %zu queue files found\n", g->gl_pathc);
-        for (int i = 0; i < g->gl_pathc;i++) {
-            printf("   %s\n", g->gl_pathv[i]);
-        }
-    }
-
-    if (queue->version == 4) {
-        // For v4, we need to read a 'queue' header from any one of the datafiles to get the
-        // rollover configuration. We don't know how to generate a filename from a cycle code
-        // yet, so this needs to use the directory listing.
-
-        if (g->gl_pathc < 1) {
-            return krr("V4 and no queue files found so cannot initialise. Set SHMIPC_INIT_CREATE to allow queue creation");
-        }
-
-        int               queuefile_fd;
-        struct stat       queuefile_statbuf;
-        uint64_t          queuefile_extent;
-        unsigned char*    queuefile_buf;
-
-        char* fn = queue->queuefile_glob.gl_pathv[0];
-        // find length of queuefile and mmap
-        if ((queuefile_fd = open(fn, O_RDONLY)) < 0) {
-            return orr("qfi open");
-        }
-        if (fstat(queuefile_fd, &queuefile_statbuf) < 0)
-            return krr("qfi fstat");
-
-        // only need the first block
-        queuefile_extent = queuefile_statbuf.st_size < queue->blocksize ? queuefile_statbuf.st_size : queue->blocksize;
-
-        if ((queuefile_buf = mmap(0, queuefile_extent, PROT_READ, MAP_SHARED, queuefile_fd, 0)) == MAP_FAILED)
-            return krr("qfi mmap fail");
-
-        // we don't need a data-parser at this stage as only need values from the header
-        if (debug) printf("shmipc: parsing queuefile %s 0..%" PRIu64 "\n", fn, queuefile_extent);
-        parse_queuefile_meta(queuefile_buf, queuefile_extent, queue);
-
-        // close queuefile
-        munmap(queuefile_buf, queuefile_extent);
-        close(queuefile_fd);
-    }
-
-    // check we loaded roll settings from queuefile or metadata
-    if (queue->version == 0) return krr("qfi version detect fail");
-    if (queue->roll_length == 0) return krr("qfi roll_length fail");
-    if (queue->roll_format == 0) return krr("qfi roll_format fail");
-    if (queue->roll_epoch == -1) return krr("qfi roll_epoch fail");
-
-    // defer this until queuefile access
-    //if (queue->index_count == 0) return krr("qfi index_count fail");
-    //if (queue->index_spacing == 0) return krr("qfi index_spacing fail");
-
-    // TODO check yyyymmdd
-    if (strcmp(queue->roll_format, "yyyyMMdd") == 0) {
-        queue->cycle2file_fn = &get_cycle_fn_yyyymmdd;
-        queue->cycle_shift = 32;
-        queue->seqnum_mask = 0x00000000FFFFFFFF;
-    } else if (strcmp(queue->roll_format, "yyyyMMdd'F'") == 0) {
-        queue->cycle2file_fn = &get_cycle_fn_yyyymmddF;
-        queue->cycle_shift = 32;
-        queue->seqnum_mask = 0x00000000FFFFFFFF;
-    } else {
-        return krr("unsupported roll_format");
-    }
-    // TODO: Logic from RollCycles.java ensures rollover occurs before we run out of index2index pages?
-    //  cycleShift = Math.max(32, Maths.intLog2(indexCount) * 2 + Maths.intLog2(indexSpacing));
-
-    // verify user-specified parser for data segments
+    queue_t* r;
+    char* dirs = &dir->s[1];
     if (strncmp(parser->s, "text", parser->n) == 0) {
-        queue->parser = &parse_data_text;
-        queue->encoder = &append_data_text;
-        queue->encodecheck = &append_check_text;
+        r = chronicle_init(dirs, &parse_kx, &sizeof_kx, &append_kx);
     } else if (strncmp(parser->s, "kx", parser->n) == 0) {
-        queue->parser = &parse_data_kx;
-        queue->encoder = &append_data_kx;
-        queue->encodecheck = &append_check_kx;
+        r = chronicle_init(dirs, &parse_kx, &sizeof_kx, &append_kx);
     } else {
         return krr("bad format: supports `kx and `text");
     }
-    if (debug) printf("shmipc: format set to %.*s\n", (int)parser->n, parser->s);
 
-    // Good to use
-    queue->next = queue_head;
-    queue->hsymbolp = dir->s;
-    queue_head = queue;
-
-    // avoids a tailer registration before we have a minimum cycle
-    shmipc_peek_queue(queue);
-    if (debug) printf("shmipc: init complete\n");
-
-    return (K)NULL;
-
-    // wip: kernel style unwinder
-//unwind_1:
-    free(queue->dirlist_name);
-    free(queue->queuefile_pattern);
-    close(queue->dirlist_fd);
-    globfree(&queue->queuefile_glob);
-    // unlink LL if entered
-    munmap(queue->dirlist, queue->dirlist_statbuf.st_size);
-//unwind_2:
-    free(queue);
-
-    return (K)NULL;
-
-}
-
-// return codes
-//    0  awaiting at &base
-//    1  we hit working
-//    2  we hit EOF
-//    3  data extent will cross base+limit
-//    4  hit data with no data parser
-//   (7  collected value - from parse_data)
-// if any entries are read the values at basep and indexp are updated
-// if parse_data returns non-zero, we pause parsing after the current item
-int parse_queue_block(unsigned char** basep, uint64_t *indexp, unsigned char* extent, wirecallbacks_t* hcbs, parsedata_f parse_data, void* userdata) {
-    uint32_t header;
-    int sz;
-    unsigned char* base = *basep;
-    uint64_t index = *indexp;
-    int pd = 0;
-    while (!pd) {
-        if (base+4 >= extent) return 3;
-        memcpy(&header, base, sizeof(header)); // relax, fn optimised away
-        // no speculative fetches before the header is read
-        asm volatile ("mfence" ::: "memory");
-
-        if (header == HD_UNALLOCATED) {
-            if (debug) printf(" %" PRIu64 " @%p unallocated\n", index, base);
-            return 0;
-        } else if ((header & HD_MASK_META) == HD_WORKING) {
-            if (debug) printf(" @%p locked for writing by pid %d\n", base, header & HD_MASK_LENGTH);
-            return 1;
-        } else if ((header & HD_MASK_META) == HD_METADATA) {
-            sz = (header & HD_MASK_LENGTH);
-            if (debug) printf(" @%p metadata size %x\n", base, sz);
-            if (base+4+sz >= extent) return 3;
-            parse_wire(base+4, sz, 0, hcbs);
-            // EventName  header
-            //   switch to header parser
-        } else if ((header & HD_MASK_META) == HD_EOF) {
-            if (debug) printf(" @%p EOF\n", base);
-            return 2;
-        } else {
-            sz = (header & HD_MASK_LENGTH);
-            if (debug) printf(" %" PRIu64 " @%p data size %x\n", index, base, sz);
-            if (parse_data) {
-                if (base+4+sz >= extent) return 3;
-                pd = parse_data(base+4, sz, index, userdata);
-            } else {
-                // bail at first data message
-                return 4;
-            }
-            index++;
-            *indexp = index;
-        }
-
-        base = base + 4 + sz;
-        *basep = base;
-    }
-    return pd;
-}
-
-void handle_dirlist_ptr(char* buf, int sz, unsigned char *dptr, wirecallbacks_t* cbs) {
-    // we are preserving *pointers* within the shared directory data page
-    // we keep the underlying mmap for life of queue
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "listing.highestCycle", sz) == 0) {
-        queue->dirlist_fields.highest_cycle = dptr;
-    } else if (strncmp(buf, "listing.lowestCycle", sz) == 0) {
-        queue->dirlist_fields.lowest_cycle = dptr;
-    } else if (strncmp(buf, "listing.modCount", sz) == 0) {
-        queue->dirlist_fields.modcount = dptr;
-    }
-}
-
-void handle_dirlist_uint32(char* buf, int sz, uint32_t data, wirecallbacks_t* cbs){
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "length", sz) == 0) {
-        if (debug) printf("  v5 roll_length set to %x\n", data);
-        queue->roll_length = data;
-    }
-}
-
-void handle_dirlist_uint8(char* buf, int sz, uint8_t data, wirecallbacks_t* cbs) {
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "epoch", sz) == 0) {
-        queue->roll_epoch = data;
-    }
-}
-
-void handle_dirlist_text(char* buf, int sz, char* data, int dsz, wirecallbacks_t* cbs) {
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "format", sz) == 0) {
-        if (debug) printf("  v5 roll_format set to %.*s\n", dsz, data);
-        queue->roll_format = strndup(data, dsz);
-    }
-}
-
-void handle_qf_uint32(char* buf, int sz, uint32_t data, wirecallbacks_t* cbs){
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "length", sz) == 0) {
-        if (debug) printf(" v4 roll_length set to %x\n", data);
-        queue->roll_length = data;
-    }
-}
-
-void handle_qf_uint16(char* buf, int sz, uint16_t data, wirecallbacks_t* cbs) {
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "indexCount", sz) == 0) {
-        queue->index_count = data;
-    } else if (strncmp(buf, "indexSpacing", sz) == 0) {
-        queue->index_spacing = data;
-    }
-}
-
-void handle_qf_uint8(char* buf, int sz, uint8_t data, wirecallbacks_t* cbs) {
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "indexSpacing", sz) == 0) {
-        queue->index_spacing = data;
-    }
-}
-
-void handle_qf_text(char* buf, int sz, char* data, int dsz, wirecallbacks_t* cbs) {
-    queue_t* queue = (queue_t*)cbs->userdata;
-    if (strncmp(buf, "format", sz) == 0) {
-        queue->roll_format = strndup(data, dsz);
-    }
-}
-
-void parse_dirlist(queue_t* queue) {
-    // dirlist mmap is the size of the fstat
-    int lim = queue->dirlist_statbuf.st_size;
-    unsigned char* base = queue->dirlist;
-    uint64_t index = 0;
-
-    wirecallbacks_t cbs;
-    bzero(&cbs, sizeof(cbs));
-    cbs.ptr_uint64 = &handle_dirlist_ptr;
-    cbs.userdata = queue;
-
-    wirecallbacks_t hcbs;
-    bzero(&hcbs, sizeof(hcbs));
-    hcbs.field_uint32 = &handle_dirlist_uint32;
-    hcbs.field_uint8 = &handle_dirlist_uint8;
-    hcbs.field_char = &handle_dirlist_text;
-    hcbs.userdata = queue;
-    parse_queue_block(&base, &index, base+lim, &hcbs, &parse_wire_data, &cbs);
-}
-
-void parse_queuefile_meta(unsigned char* base, int limit, queue_t* queue) {
-    uint64_t index = 0;
-
-    wirecallbacks_t hcbs;
-    bzero(&hcbs, sizeof(hcbs));
-    hcbs.field_uint32 = &handle_qf_uint32;
-    hcbs.field_uint16 = &handle_qf_uint16;
-    hcbs.field_uint8 =  &handle_qf_uint8;
-    hcbs.field_char = &handle_qf_text;
-    hcbs.userdata = queue;
-    parse_queue_block(&base, &index, base+limit, &hcbs, NULL, NULL);
-}
-
-K shmipc_peek(K x) {
-    queue_t *queue = queue_head;
-    while (queue != NULL) {
-        shmipc_peek_queue(queue);
-        queue = queue->next;
-    }
-    return (K)0;
-}
-
-void peek_queue_modcount(queue_t* queue) {
-    // poll shared directory for modcount
-    uint64_t modcount;
-    memcpy(&modcount, queue->dirlist_fields.modcount, sizeof(modcount));
-
-    if (queue->modcount != modcount) {
-        printf("shmipc: %s modcount changed from %" PRIu64 " to %" PRIu64 "\n", queue->hsymbolp, queue->modcount, modcount);
-        // slowpath poll
-        memcpy(&queue->modcount, queue->dirlist_fields.modcount, sizeof(modcount));
-        memcpy(&queue->lowest_cycle, queue->dirlist_fields.lowest_cycle, sizeof(modcount));
-        memcpy(&queue->highest_cycle, queue->dirlist_fields.highest_cycle, sizeof(modcount));
-    }
-}
-
-void poke_queue_modcount(queue_t* queue) {
-    // push modifications to lowestCycle, highestCycle to directory-listing mmap
-    // and atomically increment the modcount
-    uint64_t modcount;
-    memcpy(queue->dirlist_fields.highest_cycle, &queue->highest_cycle, sizeof(modcount));
-    memcpy(queue->dirlist_fields.lowest_cycle, &queue->lowest_cycle, sizeof(modcount));
-    lock_xadd(queue->dirlist_fields.modcount, 1);
-    printf("shmipc: bumped modcount\n");
-}
-
-void shmipc_peek_queue(queue_t *queue) {
-    if (debug) printf("peeking at %s\n", queue->hsymbolp);
-    peek_queue_modcount(queue);
-
-    tailer_t *tailer = queue->tailers;
-    while (tailer != NULL) {
-        shmipc_peek_tailer(queue, tailer);
-
-        tailer = tailer->next;
-    }
-}
-
-// return codes exposed via. tailer-> state
-//     0   awaiting next entry
-//     1   hit working
-//     2   missing queuefile indicated, awaiting advance or creation
-//     3   fstat failed
-//     4   mmap failed (probably fatal)
-//     5   not yet polled
-//     6   queuefile at fid needs extending on disk
-//     7   a value was collected
-const char* tailer_state_messages[] = {"AWAITING_ENTRY", "BUSY", "AWAITING_QUEUEFILE", "E_STAT", "E_MMAP", "PEEK?", "EXTEND_FAIL", "COLLECTED"};
-
-int shmipc_peek_tailer_r(queue_t *queue, tailer_t *tailer) {
-    // for each cycle file { for each block { for each entry { emit }}}
-    // this method run like a generator, suspended in the innermost
-    // iteration when we hit the end of the file and pick up at the next peek()
-    wirecallbacks_t hcbs;
-    bzero(&hcbs, sizeof(hcbs));
-
-    while (1) {
-
-        uint64_t cycle = tailer->qf_index >> queue->cycle_shift;
-        if (cycle != tailer->qf_cycle_open || tailer->qf_fn == NULL) {
-            // free fn, mmap and fid
-            if (tailer->qf_fn) {
-                free(tailer->qf_fn);
-            }
-            if (tailer->qf_buf) {
-                munmap(tailer->qf_buf, tailer->qf_mmapsz);
-                tailer->qf_buf = NULL;
-            }
-            if (tailer->qf_fd > 0) { // close the fid if open
-                close(tailer->qf_fd);
-            }
-            tailer->qf_fn = queue->cycle2file_fn(queue, cycle);
-            tailer->qf_tip = 0;
-
-            printf("shmipc: opening cycle %" PRIu64 " filename %s\n", cycle, tailer->qf_fn);
-            int fopen_flags = O_RDONLY;
-            if (tailer->mmap_protection != PROT_READ) fopen_flags = O_RDWR;
-            if ((tailer->qf_fd = open(tailer->qf_fn, fopen_flags)) < 0) {
-                printf("shmipc:  awaiting queuefile for %s open errno=%d %s\n", tailer->qf_fn, errno, strerror(errno));
-
-                // if our cycle < highCycle, permitted to skip a missing file rather than wait
-                if (cycle < queue->highest_cycle) {
-                    uint64_t skip_to_index = (cycle + 1) << queue->cycle_shift;
-                    printf("shmipc:  skipping queuefile (cycle < highest_cycle), bumping next_index from %" PRIu64 " to %" PRIu64 "\n", tailer->qf_index, skip_to_index);
-                    tailer->qf_index = skip_to_index;
-                    continue;
-                }
-                return 2;
-            }
-            tailer->qf_cycle_open = cycle;
-
-            // renew the stat
-            if (fstat(tailer->qf_fd, &tailer->qf_statbuf) < 0) return 3;
-        }
-
-        // assert: we have open fid
-
-        //                        qf_tip
-        //    file  0               v          stat.sz
-        //          [-------------#######-------]
-        //    map                 #######
-        //                        ^      ^
-        //                     mmapoff  +mmapsz
-        //                          | basep
-        //  addr               qf_buf
-        // assign mmap limit and offset from tip and blocksize
-
-        // note: blocksize may have changed, unroll this to a constant with care
-        uint64_t blocksize_mask = ~(queue->blocksize-1);
-        uint64_t mmapoff = tailer->qf_tip & blocksize_mask;
-
-        // renew stat if we would otherwise map less than 2* blocksize
-        // TODO: write needs to extend file here!
-        if (tailer->qf_statbuf.st_size - mmapoff < 2*queue->blocksize) {
-            if (debug) printf("shmmain: approaching file size limit, less than two blocks remain\n");
-            if (fstat(tailer->qf_fd, &tailer->qf_statbuf) < 0)
-                return 3;
-            // signal to extend queuefile iff we are an appending tailer
-            if (tailer->qf_statbuf.st_size - mmapoff < 2*queue->blocksize && tailer->mmap_protection != PROT_READ) {
-                return 6;
-            }
-        }
-
-        int limit = tailer->qf_statbuf.st_size - mmapoff > 2*queue->blocksize ? 2*queue->blocksize : tailer->qf_statbuf.st_size - mmapoff;
-        if (debug) printf("shmipc:  tip %" PRIu64 " -> mmapoff %" PRIu64 " size 0x%x  blocksize_mask 0x%" PRIx64 "\n", tailer->qf_tip, mmapoff, limit, blocksize_mask);
-
-        // only re-mmap if desired window has changed since last scan
-        if (tailer->qf_buf == NULL || mmapoff != tailer->qf_mmapoff || limit != tailer->qf_mmapsz) {
-            if ((tailer->qf_buf)) {
-                munmap(tailer->qf_buf, tailer->qf_mmapsz);
-                tailer->qf_buf = NULL;
-            }
-
-            tailer->qf_mmapsz = limit;
-            tailer->qf_mmapoff = mmapoff;
-            if ((tailer->qf_buf = mmap(0, tailer->qf_mmapsz, tailer->mmap_protection, MAP_SHARED, tailer->qf_fd, tailer->qf_mmapoff)) == MAP_FAILED) {
-                printf("shmipc:  mmap failed %s %" PRIx64 " size %" PRIx64 " error=%s\n", tailer->qf_fn, tailer->qf_mmapoff, tailer->qf_mmapsz, strerror(errno));
-                tailer->qf_buf = NULL;
-                return 4;
-            }
-            printf("shmipc:  mmap offset %" PRIx64 " size %" PRIx64 " base=%p extent=%p\n", tailer->qf_mmapoff, tailer->qf_mmapsz, tailer->qf_buf, tailer->qf_buf+tailer->qf_mmapsz);
-        }
-
-        unsigned char* basep = (tailer->qf_tip - tailer->qf_mmapoff) + tailer->qf_buf; // basep within mmap
-        unsigned char* basep_old = basep;
-        unsigned char* extent = tailer->qf_buf+tailer->qf_mmapsz;
-        uint64_t index = tailer->qf_index;
-
-        //    0  awaiting at &base  (pass)
-        //    1  we hit working     (pass)
-        //    2  we hit EOF         (handle)
-        //    3  data extent will cross base+limit (handle)
-        //    4  hit data with no data parser (won't happen)
-        //    7  collected item
-        // if any entries are read the values at basep and indexp are updated
-        int s = parse_queue_block(&basep, &index, extent, &hcbs, queue->parser, tailer);
-        //printf("shmipc: block parser result %d, shm %p to %p\n", s, basep_old, basep);
-
-        if (s == 3 && basep == basep_old) {
-            queue_double_blocksize(queue);
-        }
-
-        if (basep != basep_old) {
-            // commit result of parsing to the tailer, adjusting for the window
-            uint64_t new_tip = basep-tailer->qf_buf + tailer->qf_mmapoff;
-            if (debug) printf("shmipc:  parser moved shm %p to %p, file %" PRIu64 " -> %" PRIu64 ", index %" PRIu64 " to %" PRIu64 "\n", basep_old, basep, tailer->qf_tip, new_tip, tailer->qf_index, index);
-            tailer->qf_tip = new_tip;
-            tailer->qf_index = index;
-        }
-
-        if (s == 1 || s == 7) return s;
-
-        if (s == 0) { // awaiting at end of queuefile
-            if (cycle < queue->highest_cycle-patch_cycles) { // allowed to fast-forward
-                uint64_t skip_to_index = (cycle + 1) << queue->cycle_shift;
-                printf("shmipc:  missing EOF for queuefile (cycle < highest_cycle-patch_cycles), bumping next_index from %" PRIu64 " to %" PRIu64 "\n", tailer->qf_index, skip_to_index);
-                tailer->qf_index = skip_to_index;
-                continue;
-            }
-            return s;
-        }
-
-        if (s == 2) {
-            // we've read an EOF marker, so the next expected index is cycle++, seqnum=0
-            uint64_t eof_cycle = ((tailer->qf_index >> queue->cycle_shift) + 1) << queue->cycle_shift;
-            printf("shmipc:  hit EOF marker, setting next_index from %" PRIu64 " to %" PRIu64 "\n", tailer->qf_index, eof_cycle);
-            tailer->qf_index = eof_cycle;
-        }
-    }
-    return 0;
-}
-
-int shmipc_peek_tailer(queue_t *queue, tailer_t *tailer) {
-    return tailer->state = shmipc_peek_tailer_r(queue, tailer);
-}
-
-K shmipc_debug(K x) {
-    printf("shmipc: open handles\n");
-
-    queue_t *current = queue_head;
-    while (current != NULL) {
-        printf(" handle              %s\n",   current->hsymbolp);
-        printf("  blocksize          %x\n",   current->blocksize);
-        printf("  version            %d\n",   current->version);
-        printf("  dirlist_name       %s\n",   current->dirlist_name);
-        printf("  dirlist_fd         %d\n",   current->dirlist_fd);
-        printf("  dirlist_sz         %" PRIu64 "\n", (uint64_t)current->dirlist_statbuf.st_size);
-        printf("  dirlist            %p\n",   current->dirlist);
-        printf("    cycle-low        %" PRIu64 "\n", current->lowest_cycle);
-        printf("    cycle-high       %" PRIu64 "\n", current->highest_cycle);
-        printf("    modcount         %" PRIu64 "\n", current->modcount);
-        printf("  queuefile_pattern  %s\n",   current->queuefile_pattern);
-        printf("    cycle_shift      %d\n",   current->cycle_shift);
-        printf("    roll_epoch       %d\n",   current->roll_epoch);
-        printf("    roll_length (ms) %d\n",   current->roll_length);
-        printf("    roll_format      %s\n",   current->roll_format);
-        printf("    index_count      %d\n",   current->index_count);
-        printf("    index_spacing    %d\n",   current->index_spacing);
-
-        printf("  tailers:\n");
-        tailer_t *tailer = current->tailers; // shortcut to save both collections
-        while (tailer != NULL) {
-            shmipc_debug_tailer(current, tailer);
-            tailer = tailer->next;
-        }
-        printf("  appender:\n");
-        if (current->appender)
-            shmipc_debug_tailer(current, current->appender);
-
-        current = current->next;
-    }
-    return 0;
-}
-
-void shmipc_debug_tailer(queue_t* queue, tailer_t* tailer) {
-    const char* state_text = tailer_state_messages[tailer->state];
-    printf("    callback         %p\n",   tailer->callback);
-    uint cycle = tailer->dispatch_after >> queue->cycle_shift;
-    uint seqnum = tailer->dispatch_after & queue->seqnum_mask;
-    printf("    dispatch_after   %" PRIu64 " (cycle %u, seqnum %u)\n", tailer->dispatch_after, cycle, seqnum);
-    printf("    state            %d - %s\n", tailer->state, state_text);
-    printf("    qf_fn            %s\n",   tailer->qf_fn);
-    printf("    qf_fd            %d\n",   tailer->qf_fd);
-    printf("    qf_statbuf_sz    %" PRIu64 "\n", (uint64_t)tailer->qf_statbuf.st_size);
-    printf("    qf_tip           %" PRIu64 "\n", tailer->qf_tip);
-    cycle = tailer->qf_index >> queue->cycle_shift;
-    seqnum = tailer->qf_index & queue->seqnum_mask;
-    printf("    qf_index         %" PRIu64 " (cycle %u, seqnum %u)\n", tailer->qf_index, cycle, seqnum);
-    printf("    qf_buf           %p\n",   tailer->qf_buf);
-    printf("      extent         %p\n",   tailer->qf_buf+tailer->qf_mmapsz);
-    printf("    qf_mmapsz        %" PRIx64 "\n", tailer->qf_mmapsz);
-    printf("    qf_mmapoff       %" PRIx64 "\n", tailer->qf_mmapoff);
-}
-
-K shmipc_append(K dir, K msg) {
-    return shmipc_append_ts(dir,msg,NULL);
+    return kj(r == NULL ? -1: 0);
 }
 
 K shmipc_append_ts(K dir, K msg, K ms) {
@@ -931,28 +131,8 @@ K shmipc_append_ts(K dir, K msg, K ms) {
     if (dir->s[0] != ':') return krr("dir is not symbol handle :");
     if (ms != NULL && ms->t != -KJ) return krr("ms NULL or J milliseconds");
 
-    // Appending logic
-    // 0) catch up to the end of the current file.
-    //   if hit EOF then we need to wait for creation of next file, poll modcount
-    //   then try opening filehandle
-    // Else we may be only writer
-    // a) determine if we need to roll to a new file - other writers may be idle
-    //     call gtod and calculate current cycle
-    //
-    //    - CAS loop to write EOF marker
-    //     create new queue file
-    //     update maxcycle and then increment modcount
-    // or
-    // b) write to current file
-    //     Is this entry indexable?
-    //       Is the index currently full
-    //     Write Entry
-    //        if mod % index, write back to index
-    //        if index full, write new index page, write back to index2index
-    //        when update index page, then write data
-    //   Before write, CAS operation to put working indicator on last entry
-    //    if fail, loop waiting for unlock. If EOF then fail is broken, retry
-    //    if data or index, skip over them and attempt again on newest page
+    long millis = -1;
+    if (ms) millis = ms->j;
 
     // check if queue already open
     queue_t *queue = queue_head;
@@ -962,178 +142,28 @@ K shmipc_append_ts(K dir, K msg, K ms) {
     }
     if (queue == NULL) return krr("dir must be shmipc.init[] first");
 
-    // caution: encodecheck may tweak blocksize, do not redorder below shmipc_peek_tailer
-    msg = queue->encodecheck(queue, msg); // abort write if r==0
-    if (msg == NULL) return msg;
-
-    // refresh highest and lowest, allowing our appender to follow another appender
-    peek_queue_modcount(queue);
-
-    // build a special tailer with the protection bits and file descriptor set to allow
-    // writing.
-    if (queue->appender == NULL) {
-        tailer_t* tailer = malloc(sizeof(tailer_t));
-        if (tailer == NULL) return krr("am fail");
-        bzero(tailer, sizeof(tailer_t));
-
-        // compat: writers do an extended lookback to patch missing EOFs
-        tailer->qf_index = (queue->highest_cycle - patch_cycles) << queue->cycle_shift;
-        tailer->callback = NULL;
-        tailer->state = 5;
-        tailer->mmap_protection = PROT_READ | PROT_WRITE;
-
-        queue->appender = tailer;
-
-        // re-open directory-listing mapping in read-write mode
-        K x = ee(directory_listing_reopen(queue, O_RDWR, PROT_READ | PROT_WRITE));
-        if (x && x->t == KERR && x->s) {
-            printf("shmipc: rw dir listing %p %s\n", x, x->s); return krr(x->s);
-        }
-        if (debug) printf("shmipc: appender created\n");
-    }
-    tailer_t* appender = queue->appender;
-
-
-    // if given a clock, use this to switch cycle
-    // which may be higher that maxCycle, in which case we need to poke the directory-listing
-    // TODO: move inside write loop to trigger EOF
-    if (ms) {
-        uint64_t cyc = (ms->j - queue->roll_epoch) / queue->roll_length;
-        if (cyc != appender->qf_index >> queue->cycle_shift) {
-            printf("shmipc: appender setting cycle from timestamp: current %" PRIu64 " proposed %" PRIu64 "\n", appender->qf_index >> queue->cycle_shift, cyc);
-            appender->qf_index = cyc << queue->cycle_shift;
-        }
+    // convert msg based on the format selected
+    // TODO: support text etc etc?
+    K enc = b9(3, msg);
+    if (enc == NULL) {
+        return krr("shmipc: failed to serialise msg using b9");
     }
 
-    // poll the appender
-    while (1) {
-        int r = shmipc_peek_tailer(queue, appender);
-        // TODO: 2nd call defensive to ensure 1 whole blocksize is available to put
-        r = shmipc_peek_tailer(queue, appender);
-        if (debug) printf("shmipc: writeloop appender in state %d\n", r);
-
-        if (r == 2) {
-            // our cycle is pointing to a queuefile that does not exist
-            // as we are writer, create it with temporary filename, atomically
-            // move it to the desired name, then bump the global highest_cycle
-            // value if rename succeeded
-            char* fn_buf;
-            asprintf(&fn_buf, "%s.%d.tmp", appender->qf_fn, pid_header);
-
-            // if queuefile_init fails via. krr, re-throw the error and abort the write
-            K x = ee(queuefile_init(fn_buf, queue));
-            if (x && x->t == KERR && x->s) {
-                printf("shmipc: queuefile_init error %p %s\n", x, x->s); return krr(x->s);
-            }
-
-            if (rename(fn_buf, appender->qf_fn) != 0) {
-                // rename failed, maybe raced with another writer, delay and try again
-                printf("shmipc: create queuefile %s failed at rename, errno %d\n", fn_buf, errno);
-                sleep(1);
-                continue;
-            }
-            printf("renamed %s to %s\n", fn_buf, appender->qf_fn);
-            free(fn_buf);
-
-            // rename worked, we can now re-try the peek_tailer
-            continue;
-        }
-
-        if (r == 6) {
-            // current queuefile has less than two blocks remaining, needs extending
-            // should the extend fail, we are having disk issues, wait until fixed
-            uint64_t extend_to = appender->qf_statbuf.st_size + qf_disk_sz;
-            if (lseek(appender->qf_fd, extend_to - 1, SEEK_SET) == -1) {
-                printf("shmmain: extend queuefile %s failed at lseek: %s\n", appender->qf_fn, strerror(errno));
-                sleep(1);
-                continue;
-            }
-            if (write(appender->qf_fd, "", 1) != 1) {
-                printf("shmmain: extend queuefile %s failed at write: %s\n", appender->qf_fn, strerror(errno));
-                sleep(1);
-                continue;
-            }
-            printf("shmmain: extended queuefile %s to %" PRIu64 " bytes\n", appender->qf_fn, extend_to);
-            continue;
-        }
-
-        // If the tailer returns 0, we are all set pointing to the next unwritten entry.
-        // if we write to qf_buf and the state is not zero we'll hit sigbus etc, so sleep
-        // and wait for availability.
-        if (r != 0) {
-            printf("shmipc: Cannot write in state %d, sleeping\n", r);
-            sleep(1);
-            continue;
-        }
-
-        // TODO: encoder
-        uint32_t msz = msg->n;
-        if (msz > HD_MASK_META) return krr("`shm msg sz > 30bit");
-        if ((appender->qf_tip - appender->qf_mmapoff) + msz > appender->qf_mmapsz) {
-            printf("aborting on bug: write would segfault buffer!\n");
-            abort();
-        }
-
-        // Since appender->buf is pointing at the queue head, so we can
-        // LOCK CMPXCHG the working bit directly. If the cas failed, another writer
-        // has beaten us to it, we sleep poll the tailer and try again
-        // If the file has gone EOF, we re-visit the tailer logic which will adjust
-        // the maps and switch to the new file.
-
-        // Note that we do not extended qf_buf or qf_index after the write. Let the
-        // tailer log handle the entry we've just written in the normal way, since that will
-        // adjust the buffer window/mmap for us.
-        unsigned char* ptr = (appender->qf_tip - appender->qf_mmapoff) + appender->qf_buf;
-        uint32_t ret = lock_cmpxchgl(ptr, HD_UNALLOCATED, HD_WORKING);
-
-        // cmpxchg returns the original value in memory, so we can tell if we succeeded
-        // by looking for HD_UNALLOCATED. If we read a working bit or finished size, we lost.
-        if (ret == HD_UNALLOCATED) {
-            asm volatile ("mfence" ::: "memory");
-
-            // Java does not patch EOF on prev files if it is down during the roll, it
-            // just starts a new file. As a workaround their readers 'timeout' the wait for EOF
-            // if a higher cycle is known for the queue. I'd like to be as correct as possible, so
-            // we'll patch missing EOFs during our writes if we hold the lock. This will nudge on any
-            // readers who haven't noticed the roll.
-            if (appender->qf_index < queue->highest_cycle << queue->cycle_shift) {
-                printf("shmipc: got write lock, but about to write to queuefile < maxcycle, writing EOF\n");
-                uint32_t header = HD_EOF;
-                memcpy(ptr, &header, sizeof(header));
-                continue; // retry write in next queuefile
-            }
-
-            // TODO - use encoder
-            memcpy(ptr+4, (char*)msg->G0, msz);
-
-            asm volatile ("mfence" ::: "memory");
-            uint32_t header = msz & HD_MASK_LENGTH;
-            memcpy(ptr, &header, sizeof(header));
-
-            break;
-        }
-
-        printf("shmipc: write lock failed, peeking again\n");
-        sleep(1);
-    }
-
-    // if we've rolled a new file,inform listeners by bumping modcount
-    uint64_t cyc = appender->qf_index >> queue->cycle_shift;
-    if (cyc > queue->highest_cycle) {
-        queue->highest_cycle = cyc;
-        poke_queue_modcount(queue);
-    }
-
-    if (debug) printf("shmipc: wrote %lld bytes as index %" PRIu64 "\n", msg->n, appender->qf_index);
-
-    return kj(appender->qf_index);
+    int j = chronicle_append_ts(queue, enc, millis);
+    // TODO check return error
+    r0(enc);
+    return kj(j);
 }
 
-K shmipc_tailer(K dir, K cb, K kindex) {
+K shmipc_append(K dir, K msg) {
+    return shmipc_append_ts(dir, msg, NULL);
+}
+
+K shmipc_tailer(K dir, K callback, K index) {
     if (dir->t != -KS) return krr("dir is not symbol");
     if (dir->s[0] != ':') return krr("dir is not symbol handle :");
-    if (cb->t != 100) return krr("cb is not function");
-    if (kindex->t != -KJ) return krr("index must be J");
+    if (index->t != -KJ) return krr("index must be J");
+    // if (callback-> != function) return krr("dispatcher is not a callback");
 
     // check if queue already open
     queue_t *queue = queue_head;
@@ -1143,166 +173,52 @@ K shmipc_tailer(K dir, K cb, K kindex) {
     }
     if (queue == NULL) return krr("dir must be shmipc.init[] first");
 
-    // decompose index into cycle (file) and seqnum within file
-    uint64_t index = kindex->j;
-    int cycle = index >> queue->cycle_shift;
-    int seqnum = index & queue->seqnum_mask;
-
-    printf("shmipc: tailer added index=%" PRIu64 " (cycle=%d seqnum=%d)\n", index, cycle, seqnum);
-    if (cycle < queue->lowest_cycle) {
-        index = queue->lowest_cycle << queue->cycle_shift;
-    }
-    if (cycle > queue->highest_cycle) {
-        index = queue->highest_cycle << queue->cycle_shift;
-    }
-
-    // allocate struct, we'll link if all checks pass
-    tailer_t* tailer = malloc(sizeof(tailer_t));
-    if (tailer == NULL) return krr("tm fail");
-    bzero(tailer, sizeof(tailer_t));
-
-    tailer->dispatch_after = index - 1;
-    tailer->qf_index = index & ~queue->seqnum_mask; // start replay from first entry in file
-    tailer->callback = cb;
-    tailer->state = 5;
-    tailer->mmap_protection = PROT_READ;
-
-    tailer->next = queue->tailers; // linked list
-    queue->tailers = tailer;
-
-    tailer->queue = queue; // parent pointer
+    tailer_t* tailer = chronicle_tailer(queue, &tailer_callback_kx, callback, index->j);
 
     // maintain array for index lookup
     tailer->handle = tailer_handles_count;
     tailer_handles = realloc(tailer_handles, ++tailer_handles_count * sizeof(tailer_t*));
     tailer_handles[tailer->handle] = tailer;
-    return ki(tailer->handle);
+    K r = ki(tailer->handle);
+
+    r0(index);
+    return r;
 }
+
+
+
 
 K shmipc_collect(K idx) {
     if (idx->t != -KI) return krr("idx is not int");
     if (idx->i < 0 || idx->i >= tailer_handles_count) return krr("idx out of range");
     tailer_t* tailer = tailer_handles[idx->i];
-    tailer->collect = 1;
 
-    uint64_t delaycount = 0;
-    peek_queue_modcount(tailer->queue);
-    while (1) {
-        int r = shmipc_peek_tailer(tailer->queue, tailer);
-        if (debug) printf("collect value returns %d and object %p\n", r, tailer->collected_value);
-        if (r == 7) {
-            break;
-        }
-        if (delaycount++ >> 20) usleep(delaycount >> 20);
-    }
-    K x = tailer->collected_value;
-    tailer->collected_value = NULL;
-    return x;
+    K r = chronicle_collect(tailer);
+    return r;
 }
 
-void tailer_close(tailer_t* tailer) {
-    if (tailer->qf_fn) { // if next filename cached...
-        free(tailer->qf_fn);
-    }
-    if (tailer->qf_buf) { // if mmap() open...
-        munmap(tailer->qf_buf, tailer->qf_mmapsz);
-    }
-    if (tailer->qf_fd) { // if open() open...
-        close(tailer->qf_fd);
-    }
-    free(tailer);
-}
 
 K shmipc_close(K dir) {
     if (dir->t != -KS) return krr("dir is not symbol");
     if (dir->s[0] != ':') return krr("dir is not symbol handle :");
 
     // check if queue already open
-    queue_t **parent = &queue_head; // pointer to a queue_t pointer
     queue_t *queue = queue_head;
-
     while (queue != NULL) {
-        if (queue->hsymbolp == dir->s) {
-            *parent = queue->next; // unlink
-
-            // delete tailers
-            tailer_t *tailer = queue->tailers; // shortcut to save both collections
-            while (tailer != NULL) {
-                tailer_t* next_tmp = tailer->next;
-                tailer_close(tailer);
-                tailer = next_tmp;
-            }
-            queue->tailers = NULL;
-
-            if (queue->appender) tailer_close(queue->appender);
-
-            // kill queue
-            munmap(queue->dirlist, queue->dirlist_statbuf.st_size);
-            close(queue->dirlist_fd);
-            free(queue->dirlist_name);
-            free(queue->dirname);
-            free(queue->queuefile_pattern);
-            free(queue->roll_format);
-            globfree(&queue->queuefile_glob);
-            free(queue);
-
-            return (K)NULL;
-        }
-        parent = &queue->next;
+        if (queue->hsymbolp == dir->s) break;
         queue = queue->next;
     }
-    return krr("shmipc: close: queue does not exist");
+    if (queue == NULL) return krr("dir must be shmipc.init[] first");
+
+    int r = chronicle_close(queue);
+    return kj(r);
 }
 
-K queuefile_init(char* fn, queue_t* queue) {
-    int fd;
-    int mode = 0777;
-
-    printf("Creating %s\n", fn);
-
-    // open/create the output file
-    if ((fd = open(fn, O_RDWR | O_CREAT | O_TRUNC, mode)) < 0) {
-        printf("can't create %s for writing", fn);
-        return krr("shmipc: create tmp queuefile err");
+K shmipc_peek(K x) {
+    queue_t *queue = queue_head;
+    while (queue != NULL) {
+        chronicle_peek_queue(queue);
+        queue = queue->next;
     }
-
-    // go to the location corresponding to the last byte
-    if (lseek(fd, qf_disk_sz - 1, SEEK_SET) == -1) {
-        return krr("shmipc: lseek error");
-    }
-
-    // write a dummy byte at the last location
-    if (write(fd, "", 1) != 1) {
-        return krr("shmipc: write error");
-    }
-
-    // TODO: write header
-    // TODO: write index2index
-    printf("Created %s\n", fn);
-
-    close(fd);
-    return NULL;
-}
-
-K directory_listing_reopen(queue_t* queue, int open_flags, int mmap_prot) {
-
-    if ((queue->dirlist_fd = open(queue->dirlist_name, open_flags)) < 0) {
-        return orr("dirlist open");
-    }
-
-    // find size of dirlist and mmap
-    if (fstat(queue->dirlist_fd, &queue->dirlist_statbuf) < 0)
-        return krr("dirlist fstat");
-    if ((queue->dirlist = mmap(0, queue->dirlist_statbuf.st_size, mmap_prot, MAP_SHARED, queue->dirlist_fd, 0)) == MAP_FAILED)
-        return krr("dirlist mmap fail");
-
-    if (debug) printf("shmipc: parsing dirlist\n");
-    parse_dirlist(queue);
-
-    // check the polled fields in header section were all resolved to pointers within the map
-    if (queue->dirlist_fields.highest_cycle == NULL || queue->dirlist_fields.lowest_cycle == NULL ||
-        queue->dirlist_fields.modcount == NULL) {
-        return krr("dirlist parse hdr ptr fail");
-    }
-    return (K)NULL;
+    return (K)0;
 }

--- a/native/shmmain.c
+++ b/native/shmmain.c
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <shmipc.c>
+#include <libchronicle.c>
 #include <stdarg.h>
 #include <ctype.h>
 #include "mock_k.h"
@@ -22,109 +22,127 @@
 // globals needed by callbacks
 int print_data = 0;
 
-K printxy(K x, K y) {
-	if (print_data) {
-		printf("[%llu] ", x->j);
-		if (y->t == KC)
-			fwrite(kC(y), sizeof(char), y->n, stdout);
-		printf("\n");
-	}
-	return ki(5);
+int printxy(void* ctx, uint64_t index, K y) {
+    if (print_data) {
+        printf("[%" PRIu64 "] ", index);
+        if (y->t == KC)
+            fwrite(kC(y), sizeof(char), y->n, stdout);
+        printf("\n");
+    }
+    return 0;
 }
 
 K kfrom_c_str(const char* s) { // k symbol from string?
-	int n = strlen(s);
-	K r = ktn(KC, n);
-	memcpy((char*)r->G0, s, n);
-	return r;
+    int n = strlen(s);
+    K r = ktn(KC, n);
+    memcpy((char*)r->G0, s, n);
+    return r;
+}
+
+K parse_data(unsigned char* base, int lim) {
+    if (debug) printf(" text: '%.*s'\n", lim, base);
+    K msg = ktn(KC, lim); // don't free this, handed over to q interp
+    memcpy((char*)msg->G0, base, lim);
+    return msg;
+}
+
+int append_write(unsigned char* base, int sz, K msg) {
+    memcpy(base, (char*)msg->G0, sz);
+    return msg->n;
+}
+
+long append_sizeof(K msg) {
+    if (msg->t != KC) {
+        krr("msg must be KC");
+        return -1;
+    }
+    return msg->n;
 }
 
 int main(const int argc, char **argv) {
-	int c;
-	opterr = 0;
-	int verboseflag = 0;
-	int followflag = 0;
-	char* append = NULL;
-	uint64_t index = 0;
+    int c;
+    opterr = 0;
+    int verboseflag = 0;
+    int followflag = 0;
+    char* append = NULL;
+    uint64_t index = 0;
+    int queueflags = 0;
 
-	while ((c = getopt(argc, argv, "dmi:va:f")) != -1)
-	switch (c) {
-		case 'd':
-			print_data = 1;
-			break;
-		case 'i':
-			index = strtoull(optarg, NULL, 0);
-			break;
-		case 'v':
-			verboseflag = 1;
-			break;
-		case 'a':
-			append = optarg;
-			break;
-		case 'f':
-			followflag = 1;
-			break;
-		case '?':
-			fprintf(stderr, "Option '-%c' missing argument\n", optopt);
-			exit(2);
-		default:
-			fprintf(stderr, "Unknown option '%c'\n", c);
-			exit(3);
-	}
+    while ((c = getopt(argc, argv, "dmi:va:cf")) != -1)
+    switch (c) {
+        case 'd':
+            print_data = 1;
+            break;
+        case 'i':
+            index = strtoull(optarg, NULL, 0);
+            break;
+        case 'v':
+            verboseflag = 1;
+            break;
+        case 'a':
+            append = optarg;
+            break;
+        case 'c':
+            //queueflags = queueflags | SHMIPC_INIT_CREATE;
+            queueflags = queueflags + 1;
+            break;
+        case 'f':
+            followflag = 1;
+            break;
+        case '?':
+            fprintf(stderr, "Option '-%c' missing argument\n", optopt);
+            exit(2);
+        default:
+            fprintf(stderr, "Unknown option '%c'\n", c);
+            exit(3);
+    }
 
-	if (optind + 1 > argc) {
-		printf("Missing mandatory argument.\n Expected: %s [-d] [-m] [-i INDEX] [-v] [-a text] [-f] QUEUE\n", argv[0]);
-		printf("  -d print data\n");
-		printf("  -m print metadata\n");
-		printf("  -i INDEX resume from index\n");
-		printf("  -v verbose mode\n");
-		printf("  -a TEXT write value text\n");
-		printf("  -f follow queue for more entries (rather than exit)\n");
-		printf("\n");
-		printf("shmmain opens the chronicle-queue directory QUEUE and plays all messages from INDEX\n");
-		printf("setting -d -m -v vary the amount of printing that occurs during this\n");
-		printf("once the end of the queue is reached, if append (-a TEXT) is set, we will write a new\n");
-		printf("message containing the value TEXT.\n");
-		printf("if follow (-f) is set, will we continue to poll for (and print) new messages, else exit.\n");
-		exit(1);
-	}
+    if (optind + 1 > argc) {
+        printf("Missing mandatory argument.\n Expected: %s [-d] [-m] [-i INDEX] [-v] [-a text] [-f] QUEUE\n", argv[0]);
+        printf("  -d print data\n");
+        printf("  -m print metadata\n");
+        printf("  -i INDEX resume from index\n");
+        printf("  -v verbose mode\n");
+        printf("  -a TEXT write value text\n");
+        printf("  -c create QUEUE directory and files if it does not exist\n");
+        printf("  -f follow queue for more entries (rather than exit)\n");
+        printf("  -4 -5 set expected version");
+        printf("\n");
+        printf("shmmain opens the chronicle-queue directory QUEUE and plays all messages from INDEX\n");
+        printf("adding -c allows the queue to be created (and any parent directories) if it does not exist.\n");
+        printf("setting -d -m -v vary the amount of printing that occurs during this\n");
+        printf("once the end of the queue is reached, if append (-a TEXT) is set, we will write a new\n");
+        printf("message containing the value TEXT.\n");
+        printf("if follow (-f) is set, will we continue to poll for (and print) new messages, else exit.\n");
+        exit(1);
+    }
 
-	// what follows is translated q calls from shmipc.q
-	K dir = kss(argv[optind]);
-	K parser = kss("text");
-	per(shmipc_init(dir, parser));
+    // what follows is translated q calls from shmipc.q
+    char* dir = argv[optind];
+    queue_t* queue = chronicle_init(dir, &parse_data, &append_sizeof, &append_write);
 
-	K cb = dl(&printxy, 2);
-	K kindex = kj(index);
-	per(shmipc_tailer(dir,cb,kindex));
-	per(shmipc_peek(dir));
+    // tailer_t* tailer =
+    chronicle_tailer(queue, &printxy, NULL, index);
 
-	if (verboseflag) {
-		per(shmipc_debug((K)NULL));
-	}
+    chronicle_peek();
 
-	if (append) {
-		printf("writing %s\n", append);
-		K msg = kfrom_c_str(append);
-		per(shmipc_append(dir,msg));
-		r0(msg);
-	}
+    if (verboseflag) chronicle_debug();
 
-	while (followflag) {
-		usleep(500*1000);
-		per(shmipc_peek(dir));
-	}
+    if (append) {
+        printf("writing %s\n", append);
+        K msg = kfrom_c_str(append);
+        chronicle_append(queue, msg);
+        r0(msg);
+    }
 
-	if (verboseflag) {
-		per(shmipc_debug((K)NULL));
-	}
+    while (followflag) {
+        usleep(500*1000);
+        chronicle_peek();
+    }
 
-	per(shmipc_close(dir));
+    if (verboseflag) chronicle_debug();
 
-	r0(dir);
-	r0(parser);
-	r0(cb);
-	r0(kindex);
+    chronicle_close(queue);
 
-	return 0;
+    return 0;
 }

--- a/native/test/test_queue.c
+++ b/native/test/test_queue.c
@@ -1,0 +1,72 @@
+#define _GNU_SOURCE
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+
+#include "k.h"
+#define COBJ K
+#include <libchronicle.c>
+#include <mock_k.h>
+
+long print_data(void* ctx, uint64_t index, K y) {
+    printf("[%" PRIu64 "] ", index);
+    if (y->t == KC)
+        fwrite(kC(y), sizeof(char), y->n, stdout);
+    printf("\n");
+    return 0;
+}
+
+K parse_data(unsigned char* base, int lim) {
+    if (debug) printf(" text: '%.*s'\n", lim, base);
+    K msg = ktn(KC, lim); // don't free this, handed over to q interp
+    memcpy((char*)msg->G0, base, lim);
+    return msg;
+}
+
+int append_data(unsigned char* base, int sz, K msg) {
+    memcpy(base, (char*)msg->G0, sz);
+    return msg->n;
+}
+
+long sizeof_data(K msg) {
+    return msg->n;
+}
+
+static void queue_not_exist(void **state) {
+    queue_t* queue = chronicle_init("q2", &parse_data, &sizeof_data, &append_data);
+    assert_null(queue);
+    assert_string_equal(chronicle_strerror(), "dir stat fail");
+}
+
+static void queue_is_file(void **state) {
+    char* temp_dir;
+    asprintf(&temp_dir, "%s/chronicle.test.XXXXXX", P_tmpdir);
+    mkstemp(temp_dir);
+    queue_t* queue = chronicle_init(temp_dir, &parse_data, &sizeof_data, &append_data);
+    assert_null(queue);
+    assert_string_equal(chronicle_strerror(), "dir is not a directory");
+}
+
+static void queue_empty_dir_no_ver(void **state) {
+    // this will be an empty directory, so we can't tell the version
+    char* temp_dir;
+    asprintf(&temp_dir, "%s/chronicle.test.XXXXXX", P_tmpdir);
+    temp_dir = mkdtemp(temp_dir);
+    queue_t* queue = chronicle_init(temp_dir, &parse_data, &sizeof_data, &append_data);
+    assert_null(queue);
+    assert_string_equal(chronicle_strerror(), "qfi version detect fail");
+}
+
+
+int main(void) {
+
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(queue_not_exist),
+        cmocka_unit_test(queue_is_file),
+        cmocka_unit_test(queue_empty_dir_no_ver),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Splits former `shmipc.c` into `shmipc.c` which is a KDB-suitable wrapper, and the core code in `libchronicle.c` and mostly eliminate use of the K data structure by the core library. This removes unnecessary indirection in a few places and allows structures to be passed around. `libchronicle` now uses traditional `errno` based error numbers and return codes.

Added small tests suite.