### PR TITLE
Add metadata poll in collect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ native/test/*.to
 native/test/*.tok
 native/test/*.tvg
 __pycache__
+venv

--- a/bindings/python/bulkwriter.py
+++ b/bindings/python/bulkwriter.py
@@ -1,0 +1,16 @@
+import libchronicle
+import os
+import sys
+import random
+import string
+from time import sleep
+
+path = sys.argv[1]
+os.makedirs(path, mode=0o777, exist_ok=True)
+
+with libchronicle.Queue(path, version=5, create=True, roll_scheme="TEST_SECONDLY") as q:
+    for i in range(int(1e8)):
+        N = random.randrange(1, 10000)
+        line = "".join(random.choices(string.ascii_uppercase + string.digits, k=N))
+        print(q.append(line.rstrip().encode()))
+        sleep(random.randrange(1, 100) / 1000.0)

--- a/bindings/python/libchronicle.py
+++ b/bindings/python/libchronicle.py
@@ -1,27 +1,40 @@
-from ctypes import *
+from ctypes import (
+    c_void_p,
+    c_long,
+    c_longlong,
+    c_int,
+    c_char_p,
+    POINTER,
+    CFUNCTYPE,
+    Structure,
+    cdll,
+    byref,
+    string_at,
+)
 from ctypes.util import find_library
 from typing import Optional
 import os
 
 lib = find_library("chronicle")
 if lib is None:
-	# setup default lib location relative to script
-	root_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-	lib = os.path.join(root_path, 'native', 'obj', 'libchronicle.so')
+    # setup default lib location relative to script
+    root_path = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    lib = os.path.join(root_path, "native", "obj", "libchronicle.so")
 
 cx = cdll.LoadLibrary(lib)
 
-#typedef struct {
+
+# typedef struct {
 #    COBJ msg;
 #    size_t sz;
 #    uint64_t index;
-#} collected_t;
+# } collected_t;
 class Collected(Structure):
-    _fields_ = [("msg", c_void_p),
-                ("sz", c_long),
-                ("index", c_longlong)]
+    _fields_ = [("msg", c_void_p), ("sz", c_long), ("index", c_longlong)]
 
-# typedef int    (*cdispatch_f) (DISPATCH_CTX,uint64_t,COBJ);
+
 TAILER_CB = CFUNCTYPE(c_int, c_void_p, c_longlong, c_char_p)
 
 cx.chronicle_init.argtype = c_char_p
@@ -49,7 +62,6 @@ cx.chronicle_cleanup.restype = c_int
 cx.chronicle_append.argtypes = [c_void_p, c_char_p]
 cx.chronicle_append.restype = c_longlong
 
-#tailer_t* chronicle_tailer(queue_t *queue, cdispatch_f dispatcher, void* dispatch_ctx, uint64_t index) {
 cx.chronicle_tailer.argtypes = [c_void_p, c_void_p, c_void_p, c_longlong]
 cx.chronicle_tailer.restype = c_void_p
 
@@ -67,64 +79,72 @@ cx.chronicle_peek_queue.restype = None
 cx.chronicle_peek_tailer.argtypes = [c_void_p]
 cx.chronicle_peek_tailer.restype = None
 
-class Queue():
-	def __init__(self, directory: str, create: bool=False, version:int=0, roll_scheme:Optional[str]=None):
-		self.q = cx.chronicle_init(directory.encode())
-		if create:
-			cx.chronicle_set_create(self.q, 1)
-		if version != 0:
-			cx.chronicle_set_version(self.q, version)
-		if roll_scheme is not None:
-			rc = cx.chronicle_set_roll_scheme(self.q, roll_scheme.encode())
-			if rc != 0:
-				raise ValueError(f"No such roll_scheme {roll_scheme}")
 
-	def __enter__(self):
-		rc = cx.chronicle_open(self.q)
-		if rc != 0:
-			raise ValueError(f"Open failed: {cx.chronicle_strerror()}")
-		return self
+class Queue:
+    def __init__(
+        self,
+        directory: str,
+        create: bool = False,
+        version: int = 0,
+        roll_scheme: Optional[str] = None,
+    ):
+        self.q = cx.chronicle_init(directory.encode())
+        if create:
+            cx.chronicle_set_create(self.q, 1)
+        if version != 0:
+            cx.chronicle_set_version(self.q, version)
+        if roll_scheme is not None:
+            rc = cx.chronicle_set_roll_scheme(self.q, roll_scheme.encode())
+            if rc != 0:
+                raise ValueError(f"No such roll_scheme {roll_scheme}")
 
-	def __exit__(self, type, value, tb):
-		rc = cx.chronicle_cleanup(self.q)
-		if rc != 0:
-			raise ValueError(f"Close failed: {cx.chronicle_strerror()}")
+    def __enter__(self):
+        rc = cx.chronicle_open(self.q)
+        if rc != 0:
+            raise ValueError(f"Open failed: {cx.chronicle_strerror()}")
+        return self
 
-	def debug(self):
-		cx.chronicle_debug()
+    def __exit__(self, type, value, tb):
+        rc = cx.chronicle_cleanup(self.q)
+        if rc != 0:
+            raise ValueError(f"Close failed: {cx.chronicle_strerror()}")
 
-	def append(self, data: bytes):
-		return cx.chronicle_append(self.q, data)
+    def debug(self):
+        cx.chronicle_debug()
 
-	def tailer(self, index: int=0, cb=None):
-		# for now we don't use callback api, just blocking collect
-		cb_func = None
-		if cb:
-			cb_func = TAILER_CB(cb)
-		tailer = cx.chronicle_tailer(self.q, cb_func, None, index)
-		return Tailer(tailer)
+    def append(self, data: bytes):
+        return cx.chronicle_append(self.q, data)
 
-	def peek(self):
-		cx.chronicle_peek_queue(self.q)
+    def tailer(self, index: int = 0, cb=None):
+        # for now we don't use callback api, just blocking collect
+        cb_func = None
+        if cb:
+            cb_func = TAILER_CB(cb)
+        tailer = cx.chronicle_tailer(self.q, cb_func, None, index)
+        return Tailer(tailer)
 
-class Tailer():
-	def __init__(self, tailer):
-		self.tailer = tailer
-		self.collected = Collected()
+    def peek(self):
+        cx.chronicle_peek_queue(self.q)
 
-	def __enter__(self):
-		return self
 
-	def __exit__(self, type, value, tb):
-		pass
+class Tailer:
+    def __init__(self, tailer):
+        self.tailer = tailer
+        self.collected = Collected()
 
-	def collect(self, timeout=None):
-		# TODO: this blocks forever inside the native code, which
-		# prevents ctl-C from working
-		cx.chronicle_collect(self.tailer, byref(self.collected))
-		data = string_at(self.collected.msg, self.collected.sz)
-		## cx.chronicle_return(self.tailer, self.collected)
-		return (self.collected.index, data)
+    def __enter__(self):
+        return self
 
-	def peek(self):
-		cx.chronicle_peek_tailer(self.tailer)
+    def __exit__(self, type, value, tb):
+        pass
+
+    def collect(self, timeout=None):
+        # TODO: this blocks forever inside the native code, which
+        # prevents ctl-C from working
+        cx.chronicle_collect(self.tailer, byref(self.collected))
+        data = string_at(self.collected.msg, self.collected.sz)
+        ## cx.chronicle_return(self.tailer, self.collected)
+        return (self.collected.index, data)
+
+    def peek(self):
+        cx.chronicle_peek_tailer(self.tailer)

--- a/bindings/python/reader_cb.py
+++ b/bindings/python/reader_cb.py
@@ -1,9 +1,11 @@
 import libchronicle
 import sys
 
+
 def printmsg(ctx, index, bs):
     print(f"[{index}] {bs}")
     return 0
+
 
 path = sys.argv[1]
 with libchronicle.Queue(path) as q:

--- a/bindings/python/writer.py
+++ b/bindings/python/writer.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 path = sys.argv[1]
-os.makedirs(path, mode = 0o777, exist_ok=True)
+os.makedirs(path, mode=0o777, exist_ok=True)
 
 with libchronicle.Queue(path, version=5, create=True, roll_scheme="DAILY") as q:
     for line in sys.stdin:


### PR DESCRIPTION
`chronicle_collect` needs to call `peek_queue_modcount(tailer->queue)` on the slowpath to ensure that if the writer has moved by more than one `cycle` ahead, we don't keep polling for a file that will not arrive.